### PR TITLE
#50 - Add Unit Tests for Components and Services

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -15,4 +15,4 @@ jobs:
         sudo npm install --exact-versions
         sudo npm install -g @angular/cli
         sudo ng build
-        sudo ng test --watch=false
+        sudo ng test --watch=false --browsers=ChromeHeadless

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -15,4 +15,4 @@ jobs:
         sudo npm install --exact-versions
         sudo npm install -g @angular/cli
         sudo ng build
-        sudo ng test --watch=false --browsers=ChromeHeadless
+        sudo npm run test -- --configuration=headless

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -4,15 +4,20 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    env:
+      directory: ./src/Smp.Web/ClientApp
 
     steps:
     - uses: actions/checkout@v1
-    - name: npm install and ng build
+    - name: npm install
       run: |
-        cd src/Smp.Web/ClientApp
         sudo npm install --exact-versions
         sudo npm install -g @angular/cli
-        sudo ng build
-        sudo npm run test -- --configuration=headless
+      working-directory: ${{env.directory}}
+    - name:  ng build
+      run: sudo ng build
+      working-directory: ${{env.directory}}
+    - name: ng test
+      run: sudo npm run test -- --configuration=headless
+      working-directory: ${{env.directory}}

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -15,4 +15,4 @@ jobs:
         sudo npm install --exact-versions
         sudo npm install -g @angular/cli
         sudo ng build
-        sudo ng test
+        sudo ng test --watch=false

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -15,4 +15,4 @@ jobs:
         sudo npm install --exact-versions
         sudo npm install -g @angular/cli
         sudo ng build
-        sudo ng test --watch=false --browsers=ChromeHeadless
+        ng test --watch=false --browsers=ChromeHeadless

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -15,3 +15,4 @@ jobs:
         sudo npm install --exact-versions
         sudo npm install -g @angular/cli
         sudo ng build
+        sudo ng test

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -15,4 +15,4 @@ jobs:
         sudo npm install --exact-versions
         sudo npm install -g @angular/cli
         sudo ng build
-        ng test --watch=false --browsers=ChromeHeadless
+        sudo ng test --watch=false --browsers=ChromeHeadless

--- a/src/Smp.Web/ClientApp/angular.json
+++ b/src/Smp.Web/ClientApp/angular.json
@@ -93,6 +93,12 @@
               "src/assets",
               "src/favicon.ico"
             ]
+          },
+          "configurations": {
+            "headless": {
+              "watch": false,
+              "browsers": "ChromeHeadless"
+            }
           }
         },
         "lint": {

--- a/src/Smp.Web/ClientApp/angular.json
+++ b/src/Smp.Web/ClientApp/angular.json
@@ -97,7 +97,7 @@
           "configurations": {
             "headless": {
               "watch": false,
-              "browsers": "ChromeHeadless"
+              "browsers": "Headless"
             }
           }
         },

--- a/src/Smp.Web/ClientApp/karma.conf.js
+++ b/src/Smp.Web/ClientApp/karma.conf.js
@@ -25,10 +25,10 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome', 'ChromeHeadlessNoSandbox'],
+    browsers: ['Chrome'],
     singleRun: false,
     customLaunchers: {
-      ChromeHeadlessNoSandbox: {
+      ChromeHeadless: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox']
       }

--- a/src/Smp.Web/ClientApp/karma.conf.js
+++ b/src/Smp.Web/ClientApp/karma.conf.js
@@ -25,7 +25,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false
+    browsers: ['Chrome', 'ChromeHeadlessNoSandbox'],
+    singleRun: false,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    }
   });
 };

--- a/src/Smp.Web/ClientApp/karma.conf.js
+++ b/src/Smp.Web/ClientApp/karma.conf.js
@@ -28,7 +28,7 @@ module.exports = function (config) {
     browsers: ['Chrome'],
     singleRun: false,
     customLaunchers: {
-      ChromeHeadless: {
+      Headless: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox']
       }

--- a/src/Smp.Web/ClientApp/package-lock.json
+++ b/src/Smp.Web/ClientApp/package-lock.json
@@ -2784,10 +2784,9 @@
       }
     },
     "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
-      "dev": true
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
     },
     "adm-zip": {
       "version": "0.4.14",
@@ -7862,9 +7861,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -7933,9 +7932,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -7958,9 +7957,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -9238,9 +9237,9 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         },
         "to-regex": {
@@ -9560,9 +9559,9 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -12461,9 +12460,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         }
       }

--- a/src/Smp.Web/ClientApp/package-lock.json
+++ b/src/Smp.Web/ClientApp/package-lock.json
@@ -2786,7 +2786,8 @@
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "dev": true
     },
     "adm-zip": {
       "version": "0.4.14",
@@ -8373,6 +8374,15 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
       "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
       "dev": true
+    },
+    "jasmine-marbles": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-marbles/-/jasmine-marbles-0.6.0.tgz",
+      "integrity": "sha512-1uzgjEesEeCb+r+v46qn5x326TiGqk5SUZa+A3O+XnMCjG/pGcUOhL9Xsg5L7gLC6RFHyWGTkB5fei4rcvIOiQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.5.0"
+      }
     },
     "jasmine-spec-reporter": {
       "version": "4.2.1",

--- a/src/Smp.Web/ClientApp/package.json
+++ b/src/Smp.Web/ClientApp/package.json
@@ -48,6 +48,7 @@
     "hoek": "^5.0.4",
     "jasmine-core": "~2.8.0",
     "jasmine-spec-reporter": "~4.2.1",
+    "jasmine-marbles": "~0.6.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "~2.2.0",
     "karma-coverage-istanbul-reporter": "^1.4.3",

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
@@ -1,19 +1,24 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ConversationComponent } from './conversation.component';
+import { ConversationsService } from '../services/conversations.service';
+import { MessagesService } from '../services/messages.service';
+import { UsersService } from '../services/users.service';
+import { GlobalHelper } from '../helpers/global';
+import { FormBuilder } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ConversationComponent', () => {
   let component: ConversationComponent;
   let fixture: ComponentFixture<ConversationComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ConversationComponent ]
-    })
-    .compileComponents();
-  }));
-
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConversationComponent],
+      imports: [HttpClientTestingModule],
+      providers: [ConversationsService, MessagesService, UsersService, GlobalHelper, FormBuilder, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+    }).compileComponents();
+
     fixture = TestBed.createComponent(ConversationComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
@@ -1,45 +1,39 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { ConversationComponent } from './conversation.component';
-import { MessagesService } from '../services/messages.service';
 import { FormBuilder } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
+
+import { ConversationComponent } from './conversation.component';
 import { CreateMessageRequest } from '../models/requests/create-message-request';
+import { MessagesService } from '../services/messages.service';
 
 describe('ConversationComponent', () => {
-  let component: ConversationComponent;
-  let fixture: ComponentFixture<ConversationComponent>;
-  const userId = 'userid-1'
-
-  const msgReq = new CreateMessageRequest();
+  const msgReq: CreateMessageRequest = new CreateMessageRequest();
   msgReq.content = 'Message Content';
   msgReq.conversationId = 'conversationid-1';
   msgReq.senderId = 'userid-1';
+  const userId: string = 'userid-1';
+  let component: ConversationComponent;
+  let fixture: ComponentFixture<ConversationComponent>;
 
   beforeEach(() => {
     localStorage.setItem('currentUser', JSON.stringify({ id: userId }));
     TestBed.configureTestingModule({
       declarations: [ConversationComponent],
       imports: [HttpClientTestingModule],
-      providers: [ FormBuilder, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+      providers: [FormBuilder, { provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ConversationComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    let cnvId = '';
-
-    spyOnProperty(component, 'conversationId', 'set')
-      .and.callFake((convId: string) => {
-        cnvId = convId;
+    let cnvId: string = '';
+    spyOnProperty(component, 'conversationId', 'set').and.callFake((convId: string) => {
+      cnvId = convId;
     });
 
-    spyOnProperty(component, 'conversationId', 'get')
-      .and.callFake(() => {
-        return cnvId;
-    });
+    spyOnProperty(component, 'conversationId', 'get').and.callFake(() => cnvId);
   });
 
   afterEach(() => {
@@ -48,60 +42,51 @@ describe('ConversationComponent', () => {
 
   describe('sendMessage()', () => {
     beforeEach(() => {
-      spyOn(TestBed.inject(MessagesService), "createMessage")
-        .and.returnValue(of(' '));
-
+      spyOn(TestBed.inject(MessagesService), 'createMessage').and.returnValue(of(' '));
       component.form.value.content = 'Message Content';
       component.conversationId = 'conversationid-1';
     });
 
     it('should have called MessagesServices.createMessages() correctly', () => {
       component.sendMessage();
-
       expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalled();
       expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalledWith(msgReq);
     });
 
     it('should have reset the form', () => {
       component.sendMessage();
-
       expect(component.form.value.content).toEqual(null);
     });
   });
 
   describe('keyDown()', () => {
     let defaultPrevented: boolean;
-
-    const nonEnterEvent = {
+    const nonEnterEvent: KeyboardEvent = {
       keyCode: 12,
       preventDefault: () => {
         defaultPrevented = true;
         return;
-      }
+      },
     } as KeyboardEvent;
 
-    const enterEvent = {
+    const enterEvent: KeyboardEvent = {
       keyCode: 13,
       preventDefault: () => {
         defaultPrevented = true;
         return;
-      }
+      },
     } as KeyboardEvent;
 
     beforeEach(() => {
-      spyOn(TestBed.inject(MessagesService), "createMessage")
-        .and.returnValue(of(' '));
-
+      spyOn(TestBed.inject(MessagesService), 'createMessage').and.returnValue(of(' '));
       component.form.value.content = 'Message Content';
       component.conversationId = 'conversationid-1';
-
       defaultPrevented = false;
     });
 
     describe('when enter has not been pressed', () => {
       it('should not have called event.preventDefault()', () => {
         component.keyDown(nonEnterEvent);
-
         expect(defaultPrevented).toEqual(false);
       });
     });
@@ -109,20 +94,17 @@ describe('ConversationComponent', () => {
     describe('when enter has been pressed', () => {
       it('should have called event.preventDefault()', () => {
         component.keyDown(enterEvent);
-
         expect(defaultPrevented).toEqual(true);
       });
 
       it('should have called MessagesServices.createMessages() correctly', () => {
         component.keyDown(enterEvent);
-  
         expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalled();
         expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalledWith(msgReq);
       });
-  
+
       it('should have reset the form', () => {
         component.keyDown(enterEvent);
-  
         expect(component.form.value.content).toEqual(null);
       });
     });

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
@@ -15,8 +15,6 @@ describe('ConversationComponent', () => {
   let fixture: ComponentFixture<ConversationComponent>;
   const userId = 'userid-1'
 
-  let msgSvcCreateMessageSpyOn: jasmine.Spy;
-
   const msgReq = new CreateMessageRequest();
   msgReq.content = 'Message Content';
   msgReq.conversationId = 'conversationid-1';
@@ -36,12 +34,12 @@ describe('ConversationComponent', () => {
 
     let cnvId = '';
 
-    const setterSpy = spyOnProperty(component, 'conversationId', 'set')
+    spyOnProperty(component, 'conversationId', 'set')
       .and.callFake((convId: string) => {
         cnvId = convId;
     });
 
-    const getterSpy = spyOnProperty(component, 'conversationId', 'get')
+    spyOnProperty(component, 'conversationId', 'get')
       .and.callFake(() => {
         return cnvId;
     });
@@ -53,7 +51,7 @@ describe('ConversationComponent', () => {
 
   describe('sendMessage', () => {
     beforeEach(() => {
-      msgSvcCreateMessageSpyOn = spyOn(TestBed.inject(MessagesService), "createMessage")
+      spyOn(TestBed.inject(MessagesService), "createMessage")
         .and.returnValue(of(' '));
 
       component.form.value.content = 'Message Content';
@@ -63,8 +61,8 @@ describe('ConversationComponent', () => {
     it('should call MessagesServices createMessages correctly', () => {
       component.sendMessage();
 
-      expect(msgSvcCreateMessageSpyOn.calls.count()).toEqual(1);
-      expect(msgSvcCreateMessageSpyOn.calls.argsFor(0)).toEqual([msgReq]);
+      expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalled();
+      expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalledWith(msgReq);
     });
 
     it('should reset the form', () => {
@@ -94,7 +92,7 @@ describe('ConversationComponent', () => {
     } as KeyboardEvent;
 
     beforeEach(() => {
-      msgSvcCreateMessageSpyOn = spyOn(TestBed.inject(MessagesService), "createMessage")
+      spyOn(TestBed.inject(MessagesService), "createMessage")
         .and.returnValue(of(' '));
 
       component.form.value.content = 'Message Content';
@@ -121,8 +119,8 @@ describe('ConversationComponent', () => {
       it('should call MessagesServices createMessages correctly', () => {
         component.keyDown(enterEvent);
   
-        expect(msgSvcCreateMessageSpyOn.calls.count()).toEqual(1);
-        expect(msgSvcCreateMessageSpyOn.calls.argsFor(0)).toEqual([msgReq]);
+        expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalled();
+        expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalledWith(msgReq);
       });
   
       it('should reset the form', () => {

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
@@ -25,7 +25,7 @@ describe('ConversationComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ConversationComponent],
       imports: [HttpClientTestingModule],
-      providers: [ConversationsService, MessagesService, UsersService, GlobalHelper, FormBuilder, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+      providers: [ FormBuilder, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ConversationComponent);

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
@@ -49,7 +49,7 @@ describe('ConversationComponent', () => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('sendMessage', () => {
+  describe('sendMessage()', () => {
     beforeEach(() => {
       spyOn(TestBed.inject(MessagesService), "createMessage")
         .and.returnValue(of(' '));
@@ -58,21 +58,21 @@ describe('ConversationComponent', () => {
       component.conversationId = 'conversationid-1';
     });
 
-    it('should call MessagesServices createMessages correctly', () => {
+    it('should have called MessagesServices.createMessages() correctly', () => {
       component.sendMessage();
 
       expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalled();
       expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalledWith(msgReq);
     });
 
-    it('should reset the form', () => {
+    it('should have reset the form', () => {
       component.sendMessage();
 
       expect(component.form.value.content).toEqual(null);
     });
   });
 
-  describe('keyDown', () => {
+  describe('keyDown()', () => {
     let defaultPrevented: boolean;
 
     const nonEnterEvent = {
@@ -102,7 +102,7 @@ describe('ConversationComponent', () => {
     });
 
     describe('when enter has not been pressed', () => {
-      it('should not call event.preventDefault', () => {
+      it('should not have called event.preventDefault()', () => {
         component.keyDown(nonEnterEvent);
 
         expect(defaultPrevented).toEqual(false);
@@ -110,20 +110,20 @@ describe('ConversationComponent', () => {
     });
 
     describe('when enter has been pressed', () => {
-      it('should call event.preventDefault', () => {
+      it('should have called event.preventDefault()', () => {
         component.keyDown(enterEvent);
 
         expect(defaultPrevented).toEqual(true);
       });
 
-      it('should call MessagesServices createMessages correctly', () => {
+      it('should have called MessagesServices.createMessages() correctly', () => {
         component.keyDown(enterEvent);
   
         expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalled();
         expect(TestBed.inject(MessagesService).createMessage).toHaveBeenCalledWith(msgReq);
       });
   
-      it('should reset the form', () => {
+      it('should have reset the form', () => {
         component.keyDown(enterEvent);
   
         expect(component.form.value.content).toEqual(null);

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
@@ -33,6 +33,18 @@ describe('ConversationComponent', () => {
     fixture = TestBed.createComponent(ConversationComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    let cnvId = '';
+
+    const setterSpy = spyOnProperty(component, 'conversationId', 'set')
+      .and.callFake((convId: string) => {
+        cnvId = convId;
+    });
+
+    const getterSpy = spyOnProperty(component, 'conversationId', 'get')
+      .and.callFake(() => {
+        return cnvId;
+    });
   });
 
   afterEach(() => {

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.spec.ts
@@ -1,10 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ConversationComponent } from './conversation.component';
-import { ConversationsService } from '../services/conversations.service';
 import { MessagesService } from '../services/messages.service';
-import { UsersService } from '../services/users.service';
-import { GlobalHelper } from '../helpers/global';
 import { FormBuilder } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.ts
@@ -37,6 +37,7 @@ export class ConversationComponent implements OnInit {
     if (id === this._conversationId) return;
 
     this._conversationId = id;
+    this.messages = new Array<FriendlyMessage>();
     this._currentPage = 0;
     this.loadedConversation = true;
     this.users = new Map<string, User>();

--- a/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/conversation/conversation.component.ts
@@ -47,7 +47,7 @@ export class ConversationComponent implements OnInit {
       .withUrl('/hubs/messages', { accessTokenFactory: () => this.globalHelper.localStorageItem<CurrentUser>('currentUser').token })
       .build();
     this._hubConnection.start();
-    this._hubConnection.on(`newmessage/${this._conversationId}`, () => {
+    this._hubConnection.on(`newmessage/${this.conversationId}`, () => {
       this.getNewestMessages();
     });
   }
@@ -85,7 +85,7 @@ export class ConversationComponent implements OnInit {
   public sendMessage(): void {
     const createMessageRequest = new CreateMessageRequest();
     createMessageRequest.content = this.form.value.content;
-    createMessageRequest.conversationId = this._conversationId;
+    createMessageRequest.conversationId = this.conversationId;
     createMessageRequest.senderId = this.globalHelper.localStorageItem<CurrentUser>('currentUser').id;
 
     this.messagesService.createMessage(createMessageRequest).subscribe({

--- a/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
@@ -32,16 +32,13 @@ describe('CreatePostComponent', () => {
     fixture.detectChanges();
   });
 
-  describe('createPost', () => {
+  describe('createPost()', () => {
     beforeEach(() => {
       component.postToId = postToId;
       component.createPostRequest.content = 'content';
     });
 
-    let eventEmitterEmitSpy: jasmine.Spy;
-    let postsServiceCreatePostSpy: jasmine.Spy;
     const postToId = 'postToId';
-
     const postReq = new CreatePostRequest();
     postReq.content = 'content';
     postReq.senderId = 'id';
@@ -49,9 +46,9 @@ describe('CreatePostComponent', () => {
 
     describe('when it completes successfully', () => {
       beforeEach(() => {
-        postsServiceCreatePostSpy = spyOn(TestBed.get(PostsService), 'createPost')
+        spyOn(TestBed.get(PostsService), 'createPost')
           .and.returnValue(of('x'));
-        eventEmitterEmitSpy = spyOn(component.postCreated, 'emit');
+        spyOn(component.postCreated, 'emit');
       });
 
       it('should have emitted an event', () => {
@@ -60,35 +57,31 @@ describe('CreatePostComponent', () => {
         expect(component.postCreated.emit).toHaveBeenCalledTimes(1);
       });
 
-      it('should have called PostsService createPost correctly', () => {
+      it('should have called PostsService.createPost() correctly', () => {
         component.createPost();
 
-        expect(postsServiceCreatePostSpy.calls.count()).toEqual(1);
-        expect(postsServiceCreatePostSpy.calls.argsFor(0)).toEqual([
-          postReq
-        ]);
+        expect(TestBed.get(PostsService).createPost).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(PostsService).createPost).toHaveBeenCalledWith(postReq);
       });
     });
 
     describe('when an error gets returned', () => {
       beforeEach(() => {
-        postsServiceCreatePostSpy = spyOn(TestBed.get(PostsService), 'createPost').and.returnValue(
+        spyOn(TestBed.get(PostsService), 'createPost').and.returnValue(
           throwError({
             error: 'error-message'
           })
         );
       });
 
-      it('should have called PostsService createPost correctly', () => {
+      it('should have called PostsService.createPost() correctly', () => {
         component.createPost();
 
-        expect(postsServiceCreatePostSpy.calls.count()).toEqual(1);
-        expect(postsServiceCreatePostSpy.calls.argsFor(0)).toEqual([
-          postReq
-        ]);
+        expect(TestBed.get(PostsService).createPost).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(PostsService).createPost).toHaveBeenCalledWith(postReq);
       });
       
-      it('should set the error message correctly', () => {
+      it('should have set the error message correctly', () => {
         component.createPost();
 
         expect(component.errorMessage).toEqual('error-message');

--- a/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
@@ -1,19 +1,23 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CreatePostComponent } from './create-post.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { GlobalHelper } from '../helpers/global';
+import { PostsService } from '../services/posts.service';
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('CreatePostComponent', () => {
   let component: CreatePostComponent;
   let fixture: ComponentFixture<CreatePostComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ CreatePostComponent ]
-    })
-    .compileComponents();
-  }));
-
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CreatePostComponent],
+      imports: [HttpClientTestingModule, FormsModule, BrowserAnimationsModule],
+      providers: [GlobalHelper, PostsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+    }).compileComponents();
+
     fixture = TestBed.createComponent(CreatePostComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
@@ -1,12 +1,12 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
 
 import { CreatePostComponent } from './create-post.component';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { PostsService } from '../services/posts.service';
-import { FormsModule } from '@angular/forms';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { throwError, of } from 'rxjs';
 import { CreatePostRequest } from '../models/requests/create-post-request';
+import { PostsService } from '../services/posts.service';
 
 describe('CreatePostComponent', () => {
   let component: CreatePostComponent;
@@ -24,7 +24,7 @@ describe('CreatePostComponent', () => {
     TestBed.configureTestingModule({
       declarations: [CreatePostComponent],
       imports: [HttpClientTestingModule, FormsModule, BrowserAnimationsModule],
-      providers: [ { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CreatePostComponent);
@@ -33,33 +33,30 @@ describe('CreatePostComponent', () => {
   });
 
   describe('createPost()', () => {
+    const postToId: string = 'postToId';
+    const postReq: CreatePostRequest = new CreatePostRequest();
+    postReq.content = 'content';
+    postReq.senderId = 'id';
+    postReq.receiverId = postToId;
+
     beforeEach(() => {
       component.postToId = postToId;
       component.createPostRequest.content = 'content';
     });
 
-    const postToId = 'postToId';
-    const postReq = new CreatePostRequest();
-    postReq.content = 'content';
-    postReq.senderId = 'id';
-    postReq.receiverId = postToId;
-
     describe('when it completes successfully', () => {
       beforeEach(() => {
-        spyOn(TestBed.get(PostsService), 'createPost')
-          .and.returnValue(of('x'));
+        spyOn(TestBed.get(PostsService), 'createPost').and.returnValue(of('x'));
         spyOn(component.postCreated, 'emit');
       });
 
       it('should have emitted an event', () => {
         component.createPost();
-
         expect(component.postCreated.emit).toHaveBeenCalledTimes(1);
       });
 
       it('should have called PostsService.createPost() correctly', () => {
         component.createPost();
-
         expect(TestBed.get(PostsService).createPost).toHaveBeenCalledTimes(1);
         expect(TestBed.get(PostsService).createPost).toHaveBeenCalledWith(postReq);
       });
@@ -67,23 +64,17 @@ describe('CreatePostComponent', () => {
 
     describe('when an error gets returned', () => {
       beforeEach(() => {
-        spyOn(TestBed.get(PostsService), 'createPost').and.returnValue(
-          throwError({
-            error: 'error-message'
-          })
-        );
+        spyOn(TestBed.get(PostsService), 'createPost').and.returnValue(throwError({ error: 'error-message' }));
       });
 
       it('should have called PostsService.createPost() correctly', () => {
         component.createPost();
-
         expect(TestBed.get(PostsService).createPost).toHaveBeenCalledTimes(1);
         expect(TestBed.get(PostsService).createPost).toHaveBeenCalledWith(postReq);
       });
-      
+
       it('should have set the error message correctly', () => {
         component.createPost();
-
         expect(component.errorMessage).toEqual('error-message');
       });
     });

--- a/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
@@ -4,12 +4,10 @@ import { CreatePostComponent } from './create-post.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { GlobalHelper } from '../helpers/global';
 import { PostsService } from '../services/posts.service';
-import { Error } from '../models/error';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { throwError, of } from 'rxjs';
 import { CreatePostRequest } from '../models/requests/create-post-request';
-import { EventEmitter } from 'protractor';
 
 describe('CreatePostComponent', () => {
   let component: CreatePostComponent;

--- a/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CreatePostComponent } from './create-post.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { GlobalHelper } from '../helpers/global';
 import { PostsService } from '../services/posts.service';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -25,7 +24,7 @@ describe('CreatePostComponent', () => {
     TestBed.configureTestingModule({
       declarations: [CreatePostComponent],
       imports: [HttpClientTestingModule, FormsModule, BrowserAnimationsModule],
-      providers: [GlobalHelper, PostsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+      providers: [ { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CreatePostComponent);

--- a/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.ts
@@ -31,7 +31,6 @@ export class CreatePostComponent implements OnInit {
     this.createPostRequest.receiverId = this.postToId;
     this.postsService.createPost(this.createPostRequest).subscribe({
       next: () => {
-        console.log('bruhhh');
         this.loading = false;
         this.postCreated.emit(null);
       },

--- a/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/create-post/create-post.component.ts
@@ -31,6 +31,7 @@ export class CreatePostComponent implements OnInit {
     this.createPostRequest.receiverId = this.postToId;
     this.postsService.createPost(this.createPostRequest).subscribe({
       next: () => {
+        console.log('bruhhh');
         this.loading = false;
         this.postCreated.emit(null);
       },

--- a/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
@@ -3,6 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FeedComponent } from './feed.component';
 import { PostsService } from '../services/posts.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { Post } from '../models/post';
 
 describe('FeedComponent', () => {
   let component: FeedComponent;
@@ -20,7 +22,40 @@ describe('FeedComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('getPosts', () => {
+    let postsServiceGetPostsSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      postsServiceGetPostsSpy = spyOn(TestBed.inject(PostsService), 'getPosts');
+    });
+
+    describe('when there is no receiver id', () => {
+      it('PostsService getPosts should not get called', () => {
+        expect(postsServiceGetPostsSpy.calls.count()).toEqual(0);
+      });
+    });
+
+    describe('when there is a receiver id', () => {
+      const posts = [ { id: 'postid' } as Post ];
+
+      beforeEach(() => {
+        component.receiverId = 'receiverId';
+
+        postsServiceGetPostsSpy.and.returnValue(of(posts));
+      });
+
+      it('PostsService getPosts should get called', () => {
+        component.getPosts();
+
+        expect(postsServiceGetPostsSpy.calls.count()).toEqual(1);
+        expect(postsServiceGetPostsSpy.calls.argsFor(0)).toEqual(['receiverId']);
+      });
+
+      it('posts should be as expected', () => {
+        component.getPosts();
+
+        expect(component.posts).toEqual(posts);
+      });
+    })
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { FeedComponent } from './feed.component';
-import { PostsService } from '../services/posts.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
+
+import { FeedComponent } from './feed.component';
 import { Post } from '../models/post';
+import { PostsService } from '../services/posts.service';
 
 describe('FeedComponent', () => {
   let component: FeedComponent;
@@ -12,18 +12,17 @@ describe('FeedComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ FeedComponent ],
-      imports: [ HttpClientTestingModule ],
-      providers: [ { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+      declarations: [FeedComponent],
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
     }).compileComponents();
-
     fixture = TestBed.createComponent(FeedComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   describe('getPosts()', () => {
-    const posts = [ { id: 'postid' } as Post ];
+    const posts: Post[] = [{ id: 'postid' } as Post];
 
     beforeEach(() => {
       spyOn(TestBed.inject(PostsService), 'getPosts').and.returnValue(of(posts));
@@ -42,14 +41,12 @@ describe('FeedComponent', () => {
 
       it('should not have called PostsService.getPosts()', () => {
         component.getPosts();
-
         expect(TestBed.inject(PostsService).getPosts).toHaveBeenCalledTimes(1);
         expect(TestBed.inject(PostsService).getPosts).toHaveBeenCalledWith('receiverId');
       });
 
       it('posts should be as expected', () => {
         component.getPosts();
-
         expect(component.posts).toEqual(posts);
       });
     });

--- a/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
@@ -14,7 +14,7 @@ describe('FeedComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ FeedComponent ],
       imports: [ HttpClientTestingModule ],
-      providers: [ PostsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+      providers: [ { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(FeedComponent);

--- a/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
@@ -22,33 +22,29 @@ describe('FeedComponent', () => {
     fixture.detectChanges();
   });
 
-  describe('getPosts', () => {
-    let postsServiceGetPostsSpy: jasmine.Spy;
+  describe('getPosts()', () => {
+    const posts = [ { id: 'postid' } as Post ];
 
     beforeEach(() => {
-      postsServiceGetPostsSpy = spyOn(TestBed.inject(PostsService), 'getPosts');
+      spyOn(TestBed.inject(PostsService), 'getPosts').and.returnValue(of(posts));
     });
 
     describe('when there is no receiver id', () => {
-      it('PostsService getPosts should not get called', () => {
-        expect(postsServiceGetPostsSpy.calls.count()).toEqual(0);
+      it('should not have called PostsService.getPosts()', () => {
+        expect(TestBed.inject(PostsService).getPosts).toHaveBeenCalledTimes(0);
       });
     });
 
     describe('when there is a receiver id', () => {
-      const posts = [ { id: 'postid' } as Post ];
-
       beforeEach(() => {
         component.receiverId = 'receiverId';
-
-        postsServiceGetPostsSpy.and.returnValue(of(posts));
       });
 
-      it('PostsService getPosts should get called', () => {
+      it('should not have called PostsService.getPosts()', () => {
         component.getPosts();
 
-        expect(postsServiceGetPostsSpy.calls.count()).toEqual(1);
-        expect(postsServiceGetPostsSpy.calls.argsFor(0)).toEqual(['receiverId']);
+        expect(TestBed.inject(PostsService).getPosts).toHaveBeenCalledTimes(1);
+        expect(TestBed.inject(PostsService).getPosts).toHaveBeenCalledWith('receiverId');
       });
 
       it('posts should be as expected', () => {
@@ -56,6 +52,6 @@ describe('FeedComponent', () => {
 
         expect(component.posts).toEqual(posts);
       });
-    })
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/feed/feed.component.spec.ts
@@ -1,19 +1,20 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FeedComponent } from './feed.component';
+import { PostsService } from '../services/posts.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('FeedComponent', () => {
   let component: FeedComponent;
   let fixture: ComponentFixture<FeedComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ FeedComponent ]
-    })
-    .compileComponents();
-  }));
-
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FeedComponent ],
+      imports: [ HttpClientTestingModule ],
+      providers: [ PostsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+    }).compileComponents();
+
     fixture = TestBed.createComponent(FeedComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/Smp.Web/ClientApp/src/app/feed/feed.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/feed/feed.component.ts
@@ -21,6 +21,7 @@ export class FeedComponent implements OnInit {
 
   public getPosts(): void {
     if (this.receiverId) {
+      console.log("AHHHHHHHHHHH" + this.receiverId);
       this.postsService.getPosts(this.receiverId).subscribe({
         next: (posts: any) => {
           this.posts = posts;

--- a/src/Smp.Web/ClientApp/src/app/feed/feed.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/feed/feed.component.ts
@@ -5,15 +5,14 @@ import { PostsService } from '../services/posts.service';
 @Component({
   selector: 'app-feed',
   templateUrl: './feed.component.html',
-  styleUrls: ['./feed.component.scss']
+  styleUrls: ['./feed.component.scss'],
 })
 export class FeedComponent implements OnInit {
-
   @Input() receiverId: string;
 
   public posts: Post[];
 
-  constructor(private postsService: PostsService) { }
+  constructor(private postsService: PostsService) {}
 
   ngOnInit() {
     this.getPosts();
@@ -21,11 +20,10 @@ export class FeedComponent implements OnInit {
 
   public getPosts(): void {
     if (this.receiverId) {
-      console.log("AHHHHHHHHHHH" + this.receiverId);
       this.postsService.getPosts(this.receiverId).subscribe({
         next: (posts: any) => {
           this.posts = posts;
-        }
+        },
       });
     }
   }

--- a/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
@@ -23,7 +23,7 @@ describe('ForgotPasswordComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ ForgotPasswordComponent ],
       imports: [ HttpClientTestingModule, FormsModule ],
-      providers: [ AccountsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+      providers: [ { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
     })
     .compileComponents();
 

--- a/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
@@ -1,9 +1,11 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AccountsService } from '../services/accounts.service';
+import { Error } from '../models/error';
 import { FormsModule } from '@angular/forms';
+import { throwError, of } from 'rxjs';
 
 describe('ForgotPasswordComponent', () => {
   let component: ForgotPasswordComponent;
@@ -20,9 +22,69 @@ describe('ForgotPasswordComponent', () => {
     fixture = TestBed.createComponent(ForgotPasswordComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    component.accountEmail = "MiXeDcAsE@email.com";
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('startPasswordReset', () => {
+    let accountsServiceForgottenPasswordSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      accountsServiceForgottenPasswordSpy = spyOn(TestBed.inject(AccountsService), 'forgottenPassword');
+    });
+
+    describe('when AccountsService forgottenPassword is successful', () => {
+      const message = 'An email has been sent to you. Click it to reset your password!';
+
+      beforeEach(() => {
+        accountsServiceForgottenPasswordSpy
+          .and.returnValue(of(' '));
+      });
+
+      it('should call AccountsService forgottenPassword correctly', () => {
+        component.startPasswordReset();
+
+        expect(accountsServiceForgottenPasswordSpy.calls.count()).toEqual(1);
+        expect(accountsServiceForgottenPasswordSpy.calls.argsFor(0)).toEqual(['mixedcase@email.com']);
+      });
+
+      it('should have set the correct variable values', () => {
+        component.startPasswordReset();
+
+        expect(component.validationError).toBeFalsy();
+        expect(component.startPasswordResetSuccessful).toEqual(true);
+        expect(component.startPasswordResetUnsuccessful).toEqual(false);
+        expect(component.loading).toEqual(false);
+        expect(component.response).toEqual(message);
+      });
+    });
+
+    describe('when AccountsService forgottenPassword returns an error', () => {
+      const error = {
+        key: 'error',
+        value: 'error-message' 
+      } as Error;
+
+      beforeEach(() => {
+        accountsServiceForgottenPasswordSpy
+          .and.returnValue(throwError({error: error}));
+      });
+
+      it('should call AccountsService forgottenPassword correctly', () => {
+        component.startPasswordReset();
+
+        expect(accountsServiceForgottenPasswordSpy.calls.count()).toEqual(1);
+        expect(accountsServiceForgottenPasswordSpy.calls.argsFor(0)).toEqual(['mixedcase@email.com']);
+      });
+
+      it('should have set the correct variable values', () => {
+        component.startPasswordReset();
+
+        expect(component.validationError).toEqual(error);
+        expect(component.startPasswordResetSuccessful).toEqual(false);
+        expect(component.startPasswordResetUnsuccessful).toEqual(true);
+        expect(component.loading).toEqual(false);
+      });
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
@@ -42,14 +42,14 @@ describe('ForgotPasswordComponent', () => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('startPasswordReset', () => {
+  describe('startPasswordReset()', () => {
     let accountsServiceForgottenPasswordSpy: jasmine.Spy;
 
     beforeEach(() => {
       accountsServiceForgottenPasswordSpy = spyOn(TestBed.inject(AccountsService), 'forgottenPassword');
     });
 
-    describe('when AccountsService forgottenPassword is successful', () => {
+    describe('when AccountsService.forgottenPassword() is successful', () => {
       const message = 'An email has been sent to you. Click it to reset your password!';
 
       beforeEach(() => {
@@ -57,11 +57,11 @@ describe('ForgotPasswordComponent', () => {
           .and.returnValue(of(' '));
       });
 
-      it('should call AccountsService forgottenPassword correctly', () => {
+      it('should have called AccountsService.forgottenPassword() correctly', () => {
         component.startPasswordReset();
 
-        expect(accountsServiceForgottenPasswordSpy.calls.count()).toEqual(1);
-        expect(accountsServiceForgottenPasswordSpy.calls.argsFor(0)).toEqual(['mixedcase@email.com']);
+        expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledTimes(1);
+        expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledWith('mixedcase@email.com');
       });
 
       it('should have set the correct variable values', () => {
@@ -75,7 +75,7 @@ describe('ForgotPasswordComponent', () => {
       });
     });
 
-    describe('when AccountsService forgottenPassword returns an error', () => {
+    describe('when AccountsService.forgottenPassword() returns an error', () => {
       const error = {
         key: 'error',
         value: 'error-message' 
@@ -86,11 +86,11 @@ describe('ForgotPasswordComponent', () => {
           .and.returnValue(throwError({error: error}));
       });
 
-      it('should call AccountsService forgottenPassword correctly', () => {
+      it('should have called AccountsService.forgottenPassword() correctly', () => {
         component.startPasswordReset();
 
-        expect(accountsServiceForgottenPasswordSpy.calls.count()).toEqual(1);
-        expect(accountsServiceForgottenPasswordSpy.calls.argsFor(0)).toEqual(['mixedcase@email.com']);
+        expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledTimes(1);
+        expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledWith('mixedcase@email.com');
       });
 
       it('should have set the correct variable values', () => {

--- a/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { ForgotPasswordComponent } from './forgot-password.component';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { AccountsService } from '../services/accounts.service';
-import { Error } from '../models/error';
 import { FormsModule } from '@angular/forms';
-import { throwError, of } from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+
+import { AccountsService } from '../services/accounts.service';
 import { CurrentUser } from '../models/current-user';
+import { Error } from '../models/error';
+import { ForgotPasswordComponent } from './forgot-password.component';
 
 describe('ForgotPasswordComponent', () => {
   let component: ForgotPasswordComponent;
@@ -16,26 +16,23 @@ describe('ForgotPasswordComponent', () => {
     id: 'cuId',
     fullName: 'cuFullName',
     email: 'cu@email.com',
-    token: 'cuToken'
+    token: 'cuToken',
   } as CurrentUser;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ForgotPasswordComponent ],
-      imports: [ HttpClientTestingModule, FormsModule ],
-      providers: [ { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-    })
-    .compileComponents();
-
-    fixture = TestBed.createComponent(ForgotPasswordComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-
-    component.accountEmail = "MiXeDcAsE@email.com";
-  });
 
   beforeAll(() => {
     localStorage.setItem('currentUser', JSON.stringify(user));
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ForgotPasswordComponent],
+      imports: [HttpClientTestingModule, FormsModule],
+      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    component.accountEmail = 'MiXeDcAsE@email.com';
   });
 
   afterAll(() => {
@@ -43,30 +40,25 @@ describe('ForgotPasswordComponent', () => {
   });
 
   describe('startPasswordReset()', () => {
-    let accountsServiceForgottenPasswordSpy: jasmine.Spy;
-
     beforeEach(() => {
-      accountsServiceForgottenPasswordSpy = spyOn(TestBed.inject(AccountsService), 'forgottenPassword');
+      spyOn(TestBed.inject(AccountsService), 'forgottenPassword');
     });
 
     describe('when AccountsService.forgottenPassword() is successful', () => {
-      const message = 'An email has been sent to you. Click it to reset your password!';
+      const message: string = 'An email has been sent to you. Click it to reset your password!';
 
       beforeEach(() => {
-        accountsServiceForgottenPasswordSpy
-          .and.returnValue(of(' '));
+        TestBed.get(AccountsService).forgottenPassword.and.returnValue(of(' '));
       });
 
       it('should have called AccountsService.forgottenPassword() correctly', () => {
         component.startPasswordReset();
-
         expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledTimes(1);
         expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledWith('mixedcase@email.com');
       });
 
       it('should have set the correct variable values', () => {
         component.startPasswordReset();
-
         expect(component.validationError).toBeFalsy();
         expect(component.startPasswordResetSuccessful).toEqual(true);
         expect(component.startPasswordResetUnsuccessful).toEqual(false);
@@ -76,26 +68,23 @@ describe('ForgotPasswordComponent', () => {
     });
 
     describe('when AccountsService.forgottenPassword() returns an error', () => {
-      const error = {
+      const error: Error = {
         key: 'error',
-        value: 'error-message' 
+        value: 'error-message',
       } as Error;
 
       beforeEach(() => {
-        accountsServiceForgottenPasswordSpy
-          .and.returnValue(throwError({error: error}));
+        TestBed.get(AccountsService).forgottenPassword.and.returnValue(throwError({ error }));
       });
 
       it('should have called AccountsService.forgottenPassword() correctly', () => {
         component.startPasswordReset();
-
         expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledTimes(1);
         expect(TestBed.inject(AccountsService).forgottenPassword).toHaveBeenCalledWith('mixedcase@email.com');
       });
 
       it('should have set the correct variable values', () => {
         component.startPasswordReset();
-
         expect(component.validationError).toEqual(error);
         expect(component.startPasswordResetSuccessful).toEqual(false);
         expect(component.startPasswordResetUnsuccessful).toEqual(true);

--- a/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
@@ -6,10 +6,18 @@ import { AccountsService } from '../services/accounts.service';
 import { Error } from '../models/error';
 import { FormsModule } from '@angular/forms';
 import { throwError, of } from 'rxjs';
+import { CurrentUser } from '../models/current-user';
 
 describe('ForgotPasswordComponent', () => {
   let component: ForgotPasswordComponent;
   let fixture: ComponentFixture<ForgotPasswordComponent>;
+
+  const user: CurrentUser = {
+    id: 'cuId',
+    fullName: 'cuFullName',
+    email: 'cu@email.com',
+    token: 'cuToken'
+  } as CurrentUser;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -24,6 +32,14 @@ describe('ForgotPasswordComponent', () => {
     fixture.detectChanges();
 
     component.accountEmail = "MiXeDcAsE@email.com";
+  });
+
+  beforeAll(() => {
+    localStorage.setItem('currentUser', JSON.stringify(user));
+  });
+
+  afterAll(() => {
+    localStorage.removeItem('currentUser');
   });
 
   describe('startPasswordReset', () => {

--- a/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.spec.ts
@@ -1,19 +1,22 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AccountsService } from '../services/accounts.service';
+import { FormsModule } from '@angular/forms';
 
 describe('ForgotPasswordComponent', () => {
   let component: ForgotPasswordComponent;
   let fixture: ComponentFixture<ForgotPasswordComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ ForgotPasswordComponent ]
+      declarations: [ ForgotPasswordComponent ],
+      imports: [ HttpClientTestingModule, FormsModule ],
+      providers: [ AccountsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
     })
     .compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(ForgotPasswordComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/forgot-password/forgot-password.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AccountsService } from '../services/accounts.service';
+import { Error } from '../models/error';
 
 @Component({
   selector: 'app-forgot-password',

--- a/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
@@ -1,24 +1,23 @@
-import { AlreadySignedInGuard } from './already-signed-in.guard';
 import { Router } from '@angular/router';
+
+import { AlreadySignedInGuard } from './already-signed-in.guard';
 
 class MockRouter {
   navigate(path) {}
 }
 
-describe('AlreadySignedInGuard canActivate', () => {
+describe('AlreadySignedInGuard.canActivate()', () => {
   const router: Router = new MockRouter() as Router;
-  const alreadySignedInGuard = new AlreadySignedInGuard(router);
+  const alreadySignedInGuard: AlreadySignedInGuard = new AlreadySignedInGuard(router);
 
   describe('canActivate()', () => {
     it('should have returned true for a non-logged in user', () => {
       expect(alreadySignedInGuard.canActivate()).toEqual(true);
     });
-  
-    it ('should have returned false for a logged in user', () => {
-      localStorage.setItem('currentUser', 'currentUser');
-  
-      expect(alreadySignedInGuard.canActivate()).toEqual(false);
 
+    it('should have returned false for a logged in user', () => {
+      localStorage.setItem('currentUser', 'currentUser');
+      expect(alreadySignedInGuard.canActivate()).toEqual(false);
       localStorage.removeItem('currentUser');
     });
   });

--- a/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
@@ -9,21 +9,17 @@ describe('AlreadySignedInGuard canActivate', () => {
   const router: Router = new MockRouter() as Router;
   const alreadySignedInGuard = new AlreadySignedInGuard(router);
 
-  beforeAll(() => {
-    localStorage.removeItem('currentUser');
-  });
+  describe('canActivate()', () => {
+    it('should have returned true for a non-logged in user', () => {
+      expect(alreadySignedInGuard.canActivate()).toEqual(true);
+    });
+  
+    it ('should have returned false for a logged in user', () => {
+      localStorage.setItem('currentUser', 'currentUser');
+  
+      expect(alreadySignedInGuard.canActivate()).toEqual(false);
 
-  afterEach(() => {
-    localStorage.removeItem('currentUser');
-  });
-
-  it('should return true for a non-logged in user', () => {
-    expect(alreadySignedInGuard.canActivate()).toEqual(true);
-  });
-
-  it ('should return false for a logged in user', () => {
-    localStorage.setItem('currentUser', 'currentUser');
-
-    expect(alreadySignedInGuard.canActivate()).toEqual(false);
+      localStorage.removeItem('currentUser');
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
@@ -1,15 +1,25 @@
-import { TestBed, async, inject } from '@angular/core/testing';
-
 import { AlreadySignedInGuard } from './already-signed-in.guard';
+import { Router } from '@angular/router';
 
-describe('AlreadySignedInGuard', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [AlreadySignedInGuard]
-    });
+class MockRouter {
+  navigate(path) {}
+}
+
+describe('AlreadySignedInGuard canActivate', () => {
+  afterEach(() => {
+    localStorage.removeItem('currentUser');
+  })
+
+  const router: Router = new MockRouter() as Router;
+  const alreadySignedInGuard = new AlreadySignedInGuard(router);
+
+  it('should return true for a non-logged in user', () => {
+    expect(alreadySignedInGuard.canActivate()).toEqual(true);
   });
 
-  it('should ...', inject([AlreadySignedInGuard], (guard: AlreadySignedInGuard) => {
-    expect(guard).toBeTruthy();
-  }));
+  it ('should return false for a logged in user', () => {
+    localStorage.setItem('currentUser', 'currentUser');
+
+    expect(alreadySignedInGuard.canActivate()).toEqual(false);
+  });
 });

--- a/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.spec.ts
@@ -6,12 +6,16 @@ class MockRouter {
 }
 
 describe('AlreadySignedInGuard canActivate', () => {
-  afterEach(() => {
-    localStorage.removeItem('currentUser');
-  })
-
   const router: Router = new MockRouter() as Router;
   const alreadySignedInGuard = new AlreadySignedInGuard(router);
+
+  beforeAll(() => {
+    localStorage.removeItem('currentUser');
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('currentUser');
+  });
 
   it('should return true for a non-logged in user', () => {
     expect(alreadySignedInGuard.canActivate()).toEqual(true);

--- a/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/already-signed-in.guard.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 
 @Injectable()
 export class AlreadySignedInGuard implements CanActivate {
   constructor(private router: Router) { }
 
-  canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
-    if ((state.url === '/sign-in' || '/sign-up') && localStorage.getItem('currentUser')) {
+  canActivate(): Observable<boolean> | Promise<boolean> | boolean {
+    if (localStorage.getItem('currentUser')) {
       this.router.navigate(['']);
       return false;
     }

--- a/src/Smp.Web/ClientApp/src/app/guards/auth.guard.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/auth.guard.spec.ts
@@ -1,25 +1,24 @@
-import { AuthGuard } from './auth.guard';
 import { Router, RouterStateSnapshot } from '@angular/router';
+
+import { AuthGuard } from './auth.guard';
 
 class MockRouter {
   navigate(path) {}
 }
 
-describe('AuthGuard canActivate', () => {
+describe('AuthGuard.canActivate()', () => {
   const router: Router = new MockRouter() as Router;
-  const authGuard = new AuthGuard(router);
-  let state = { url: '/' } as RouterStateSnapshot;
+  const authGuard: AuthGuard = new AuthGuard(router);
+  let state: RouterStateSnapshot = { url: '/' } as RouterStateSnapshot;
 
   describe('canActivate()', () => {
     it('should have returned true for a logged in user', () => {
       localStorage.setItem('currentUser', 'currentUser');
-  
       expect(authGuard.canActivate(null, state)).toEqual(true);
-
       localStorage.removeItem('currentUser');
     });
-  
-    it ('should have returned false for a non-logged in user', () => {
+
+    it('should have returned false for a non-logged in user', () => {
       expect(authGuard.canActivate(null, state)).toEqual(false);
     });
   });

--- a/src/Smp.Web/ClientApp/src/app/guards/auth.guard.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/auth.guard.spec.ts
@@ -1,15 +1,26 @@
-import { TestBed, inject } from '@angular/core/testing';
-
 import { AuthGuard } from './auth.guard';
+import { Router, RouterStateSnapshot } from '@angular/router';
 
-describe('AuthGuard', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [AuthGuard]
-    });
+class MockRouter {
+  navigate(path) {}
+}
+
+describe('AuthGuard canActivate', () => {
+  afterEach(() => {
+    localStorage.removeItem('currentUser');
+  })
+
+  const router: Router = new MockRouter() as Router;
+  const authGuard = new AuthGuard(router);
+  let state = { url: '/' } as RouterStateSnapshot;
+
+  it('should return true for a logged in user', () => {
+    localStorage.setItem('currentUser', 'currentUser');
+
+    expect(authGuard.canActivate(null, state)).toEqual(true);
   });
 
-  it('should ...', inject([AuthGuard], (guard: AuthGuard) => {
-    expect(guard).toBeTruthy();
-  }));
+  it ('should return false for a non-logged in user', () => {
+    expect(authGuard.canActivate(null, state)).toEqual(false);
+  });
 });

--- a/src/Smp.Web/ClientApp/src/app/guards/auth.guard.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/guards/auth.guard.spec.ts
@@ -6,21 +6,21 @@ class MockRouter {
 }
 
 describe('AuthGuard canActivate', () => {
-  afterEach(() => {
-    localStorage.removeItem('currentUser');
-  })
-
   const router: Router = new MockRouter() as Router;
   const authGuard = new AuthGuard(router);
   let state = { url: '/' } as RouterStateSnapshot;
 
-  it('should return true for a logged in user', () => {
-    localStorage.setItem('currentUser', 'currentUser');
+  describe('canActivate()', () => {
+    it('should have returned true for a logged in user', () => {
+      localStorage.setItem('currentUser', 'currentUser');
+  
+      expect(authGuard.canActivate(null, state)).toEqual(true);
 
-    expect(authGuard.canActivate(null, state)).toEqual(true);
-  });
-
-  it ('should return false for a non-logged in user', () => {
-    expect(authGuard.canActivate(null, state)).toEqual(false);
+      localStorage.removeItem('currentUser');
+    });
+  
+    it ('should have returned false for a non-logged in user', () => {
+      expect(authGuard.canActivate(null, state)).toEqual(false);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/helpers/global.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/helpers/global.spec.ts
@@ -1,12 +1,56 @@
 import { TestBed } from '@angular/core/testing';
 
 import { GlobalHelper } from './global';
+import { CurrentUser } from '../models/current-user';
+import { Error } from '../models/error';
+import { HttpHeaders } from '@angular/common/http';
 
 describe('GlobalHelper', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  const globalHelper: GlobalHelper = new GlobalHelper();
 
-  it('should be created', () => {
-    const service: GlobalHelper = TestBed.get(GlobalHelper);
-    expect(service).toBeTruthy();
+  const user: CurrentUser = {
+    id: 'cuId',
+    fullName: 'cuFullName',
+    email: 'cu@email.com',
+    token: 'cuToken'
+  } as CurrentUser;
+
+  const error: Error = {
+    key: 'error-key',
+    value: 'error-value'
+  } as Error;
+
+  beforeAll(() => {
+    localStorage.setItem('currentUser', JSON.stringify(user));
+    localStorage.setItem('error', JSON.stringify(error));
+  });
+
+  afterAll(() => {
+    localStorage.removeItem('currentUser');
+    localStorage.removeItem('error');
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  describe('localStorageItem', () => {
+    it('should parse a local storage item and cast to specified type', () => {
+      const err = globalHelper.localStorageItem<Error>('error');
+      const usr = globalHelper.localStorageItem<CurrentUser>('currentUser');
+
+      expect(err).toEqual(error);
+      expect(usr).toEqual(user);
+    });
+  });
+
+  describe('getAuthHeader', () => {
+    const expectedHeaders = new HttpHeaders().set('Authorization', 'Bearer cuToken');
+
+    it('should return the correct value', () => {
+      const headers = globalHelper.getAuthHeader();
+
+      expect(headers).toEqual(expectedHeaders);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/helpers/global.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/helpers/global.spec.ts
@@ -1,24 +1,22 @@
+import { HttpHeaders } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 
-import { GlobalHelper } from './global';
 import { CurrentUser } from '../models/current-user';
 import { Error } from '../models/error';
-import { HttpHeaders } from '@angular/common/http';
+import { GlobalHelper } from './global';
 
 describe('GlobalHelper', () => {
+  const error: Error = {
+    key: 'error-key',
+    value: 'error-value',
+  } as Error;
   const globalHelper: GlobalHelper = new GlobalHelper();
-
   const user: CurrentUser = {
     id: 'cuId',
     fullName: 'cuFullName',
     email: 'cu@email.com',
-    token: 'cuToken'
+    token: 'cuToken',
   } as CurrentUser;
-
-  const error: Error = {
-    key: 'error-key',
-    value: 'error-value'
-  } as Error;
 
   beforeAll(() => {
     localStorage.setItem('currentUser', JSON.stringify(user));
@@ -34,22 +32,20 @@ describe('GlobalHelper', () => {
     TestBed.configureTestingModule({});
   });
 
-  describe('localStorageItem', () => {
-    it('should parse a local storage item and cast to specified type', () => {
-      const err = globalHelper.localStorageItem<Error>('error');
-      const usr = globalHelper.localStorageItem<CurrentUser>('currentUser');
-
+  describe('localStorageItem()', () => {
+    it('should have parsed a local storage item and casted to specified type', () => {
+      const err: Error = globalHelper.localStorageItem<Error>('error');
+      const usr: CurrentUser = globalHelper.localStorageItem<CurrentUser>('currentUser');
       expect(err).toEqual(error);
       expect(usr).toEqual(user);
     });
   });
 
-  describe('getAuthHeader', () => {
-    const expectedHeaders = new HttpHeaders().set('Authorization', 'Bearer cuToken');
+  describe('getAuthHeader()', () => {
+    const expectedHeaders: HttpHeaders = new HttpHeaders().set('Authorization', 'Bearer cuToken');
 
-    it('should return the correct value', () => {
+    it('should have returned the correct value', () => {
       const headers = globalHelper.getAuthHeader();
-
       expect(headers).toEqual(expectedHeaders);
     });
   });

--- a/src/Smp.Web/ClientApp/src/app/home/home.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/home/home.component.spec.ts
@@ -1,7 +1,8 @@
-import { TestBed, ComponentFixture } from "@angular/core/testing";
-import { HomeComponent } from "./home.component";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-describe("HomeComponent", () => {
+import { HomeComponent } from './home.component';
+
+describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
@@ -14,7 +15,7 @@ describe("HomeComponent", () => {
     fixture.detectChanges();
   });
 
-  it("should create", () => {
+  it('should have been created', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/home/home.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/home/home.component.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { HomeComponent } from "./home.component";
+
+describe("HomeComponent", () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [HomeComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.html
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="friends" class="form">
+<div *ngIf="friends.length" class="form">
     <form (ngSubmit)="f.form.valid && sendMessage()" #f="ngForm" novalidate>
         <div class="form-group" style="grid-row: span 1">
             <mat-form-field>

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.html
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.html
@@ -1,4 +1,4 @@
-<div class="form">
+<div *ngIf="friends" class="form">
     <form (ngSubmit)="f.form.valid && sendMessage()" #f="ngForm" novalidate>
         <div class="form-group" style="grid-row: span 1">
             <mat-form-field>
@@ -7,7 +7,7 @@
             </mat-form-field>
         </div>
 
-        <mat-autocomplete *ngIf="friends" [hidden]="true" #auto="matAutocomplete" [displayWith]="displayFriend.bind(this)">
+        <mat-autocomplete [hidden]="true" #auto="matAutocomplete" [displayWith]="displayFriend.bind(this)">
             <mat-option *ngFor="let friend of filteredFriends" [value]="friend.id">
                 {{ friend.fullName }}
             </mat-option>

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.html
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.html
@@ -6,13 +6,13 @@
                 [(ngModel)]="createConversationRequest.receiverId" #receiverId="ngModel" required matInput [matAutocomplete]="auto">
             </mat-form-field>
         </div>
-            
-        <mat-autocomplete [hidden]="true" #auto="matAutocomplete" [displayWith]="displayFriend.bind(this)">
+
+        <mat-autocomplete *ngIf="friends" [hidden]="true" #auto="matAutocomplete" [displayWith]="displayFriend.bind(this)">
             <mat-option *ngFor="let friend of filteredFriends" [value]="friend.id">
                 {{ friend.fullName }}
             </mat-option>
         </mat-autocomplete>
-        
+
         <div class="form-group" style="grid-row: span 10">
             <mat-form-field>
                 <textarea class="form-control" placeholder="Message" name="content"
@@ -24,6 +24,5 @@
         <div class="form-group" style="grid-row: span 1">
             <button [disabled]="loading" class="button-primary">Send <img height="20px" width="20px" *ngIf="loading" src="../../assets/img/spinner.svg" /></button>
         </div>
-        
     </form>
 </div>

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -1,17 +1,38 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MessageComposerComponent } from './message-composer.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RelationshipsService } from '../services/relationships.service';
+import { ConversationsService } from '../services/conversations.service';
+import { UsersService } from '../services/users.service';
+import { GlobalHelper } from '../helpers/global';
+import { FormsModule } from '@angular/forms';
+import { AngularMaterialModule } from '../angular-material.module';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('MessageComposerComponent', () => {
   let component: MessageComposerComponent;
   let fixture: ComponentFixture<MessageComposerComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
+    localStorage.setItem('currentUser', '{ "id": "id" }');
     TestBed.configureTestingModule({
-      declarations: [ MessageComposerComponent ]
+      declarations: [ MessageComposerComponent ],
+      imports: [HttpClientTestingModule, FormsModule, AngularMaterialModule, BrowserAnimationsModule],
+      providers: [
+        GlobalHelper,
+        RelationshipsService,
+        ConversationsService,
+        UsersService,
+        { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
+      ]
     })
     .compileComponents();
-  }));
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('currentUser');
+  })
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MessageComposerComponent);

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -1,41 +1,35 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-import { MessageComposerComponent } from './message-composer.component';
-import { RelationshipsService } from '../services/relationships.service';
-import { ConversationsService } from '../services/conversations.service';
-import { UsersService } from '../services/users.service';
-import { AngularMaterialModule } from '../angular-material.module';
 import { of, throwError } from 'rxjs';
+import { AngularMaterialModule } from '../angular-material.module';
+import { ConversationsService } from '../services/conversations.service';
+import { CreateConversationRequest } from '../models/requests/create-conversation-request';
+import { MessageComposerComponent } from './message-composer.component';
 import { Relationship } from '../models/relationship';
 import { RelationshipType } from '../models/relationship-type.enum';
+import { RelationshipsService } from '../services/relationships.service';
 import { User } from '../models/user';
-import { CreateConversationRequest } from '../models/requests/create-conversation-request';
+import { UsersService } from '../services/users.service';
 
 describe('MessageComposerComponent', () => {
+  const friends: User[] = [
+    { id: 'userid-1', fullName: 'Jack Ryan' },
+    { id: 'userid-2', fullName: 'Tom Cruise' },
+  ] as User[];
+  const userId: string = 'userid-1';
   let component: MessageComposerComponent;
   let fixture: ComponentFixture<MessageComposerComponent>;
-
-  const userId = 'userid-1'
-
-  const friends = [
-    { id: 'userid-1', fullName: 'Jack Ryan' } as User,
-    { id: 'userid-2', fullName: 'Tom Cruise' } as User
-  ];
 
   beforeEach(() => {
     localStorage.setItem('currentUser', JSON.stringify({ id: userId }));
     TestBed.configureTestingModule({
-      declarations: [ MessageComposerComponent ],
+      declarations: [MessageComposerComponent],
       imports: [HttpClientTestingModule, FormsModule, AngularMaterialModule, BrowserAnimationsModule],
-      providers: [
-        { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
-      ]
-    })
-    .compileComponents();
-
+      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
+    }).compileComponents();
     fixture = TestBed.createComponent(MessageComposerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -45,42 +39,37 @@ describe('MessageComposerComponent', () => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('filterFriends', () => {
+  describe('filterFriends()', () => {
     beforeEach(() => {
       component.filteredFriends = null;
       component.friends = friends;
     });
 
-    it('should set filteredFriends correctly', () => {
+    it('should have set filteredFriends correctly', () => {
       component.filterFriends(' Rya');
       expect(component.filteredFriends).toEqual([friends[0]]);
-
       component.filterFriends('om C');
       expect(component.filteredFriends).toEqual([friends[1]]);
     });
   });
 
-  describe('displayFriend', () => {
+  describe('displayFriend()', () => {
     beforeEach(() => {
       component.friends = friends;
     });
 
-    it('should return the expected value', () => {
+    it('should have returned the expected value', () => {
       const friend = component.displayFriend('userid-2');
       expect(friend).toEqual('Tom Cruise');
-
       const nonFriend = component.displayFriend('userid-3');
       expect(nonFriend).toEqual('Unknown');
     });
   });
 
-  describe('sendMessage', () => {
-    let cnvSvcCreateConversationSpy: jasmine.Spy;
-    let conversationReadyEmitSpy: jasmine.Spy;
-
+  describe('sendMessage()', () => {
     beforeEach(() => {
-      cnvSvcCreateConversationSpy = spyOn(TestBed.inject(ConversationsService), 'createConversation')
-      conversationReadyEmitSpy = spyOn(component.conversationReady, 'emit');
+      spyOn(TestBed.inject(ConversationsService), 'createConversation');
+      spyOn(component.conversationReady, 'emit');
       component.friends = friends;
     });
 
@@ -89,127 +78,115 @@ describe('MessageComposerComponent', () => {
         component.createConversationRequest.receiverId = 'userid-3';
       });
 
-      it('should not call ConversationsService createConversation', () => {
+      it('should not have called ConversationsService.createConversation()', () => {
         component.sendMessage();
-
-        expect(cnvSvcCreateConversationSpy.calls.count()).toEqual(0);
+        expect(TestBed.get(ConversationsService).createConversation).toHaveBeenCalledTimes(0);
       });
     });
 
-    describe('if ConversationsService createConversation returns a conflict error', () => {
-      let convReq = new CreateConversationRequest();
+    describe('if ConversationsService.createConversation() returns a conflict error', () => {
+      const convReq: CreateConversationRequest = new CreateConversationRequest();
+      convReq.receiverId = friends[1].id;
+      convReq.senderId = userId;
 
       beforeEach(() => {
         component.createConversationRequest.receiverId = friends[1].id;
-        cnvSvcCreateConversationSpy
-          .and.returnValue(throwError({ status: 409, error: 'conversationid-error' }));
-        convReq.receiverId = friends[1].id;
-        convReq.senderId = userId;
+        TestBed.get(ConversationsService).createConversation.and.returnValue(
+          throwError({ status: 409, error: 'conversationid-error' })
+        );
       });
 
-      it('should call ConversationsService createConversation correctly', () => {
+      it('should have called ConversationsService.createConversation() correctly', () => {
         component.sendMessage();
-
-        expect(cnvSvcCreateConversationSpy.calls.count()).toEqual(1);
-        expect(cnvSvcCreateConversationSpy.calls.argsFor(0)).toEqual([convReq]);
+        expect(TestBed.get(ConversationsService).createConversation).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(ConversationsService).createConversation).toHaveBeenCalledWith(convReq);
       });
 
-      it('should emit a conversationReady event', () => {
+      it('should have emitted a conversationReady event', () => {
         component.sendMessage();
-
-        expect(conversationReadyEmitSpy.calls.count()).toEqual(1);
-        expect(conversationReadyEmitSpy.calls.argsFor(0)).toEqual(['conversationid-error']);
+        expect(component.conversationReady.emit).toHaveBeenCalledTimes(1);
+        expect(component.conversationReady.emit).toHaveBeenCalledWith('conversationid-error');
       });
 
       it('should have set variables correctly', () => {
         component.sendMessage();
-
         expect(component.loading).toEqual(false);
       });
     });
 
     describe('if it completes successfully', () => {
-      let convReq = new CreateConversationRequest();
+      let convReq: CreateConversationRequest = new CreateConversationRequest();
 
       beforeEach(() => {
         component.createConversationRequest.receiverId = friends[1].id;
-        cnvSvcCreateConversationSpy
-          .and.returnValue(of('conversationid-1'));
+        TestBed.get(ConversationsService).createConversation.and.returnValue(of('conversationid-1'));
         convReq.receiverId = friends[1].id;
         convReq.senderId = userId;
       });
 
-      it('should call ConversationsService createConversation correctly', () => {
+      it('should have called ConversationsService.createConversation() correctly', () => {
         component.sendMessage();
-
-        expect(cnvSvcCreateConversationSpy.calls.count()).toEqual(1);
-        expect(cnvSvcCreateConversationSpy.calls.argsFor(0)).toEqual([convReq]);
+        expect(TestBed.get(ConversationsService).createConversation).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(ConversationsService).createConversation).toHaveBeenCalledWith(convReq);
       });
 
-      it('should emit a conversationReady event', () => {
+      it('should have emitted a conversationReady event', () => {
         component.sendMessage();
-
-        expect(conversationReadyEmitSpy.calls.count()).toEqual(1);
-        expect(conversationReadyEmitSpy.calls.argsFor(0)).toEqual(['conversationid-1']);
+        expect(component.conversationReady.emit).toHaveBeenCalledTimes(1);
+        expect(component.conversationReady.emit).toHaveBeenCalledWith('conversationid-1');
       });
 
       it('should have set variables correctly', () => {
         component.sendMessage();
-
         expect(component.loading).toEqual(false);
       });
     });
   });
 
-  describe('ngOnInit', () => {
-    let relSvcGetRelationshipsSpy: jasmine.Spy;
-    let usrSvcGetUserSpy: jasmine.Spy;
-
+  describe('ngOnInit()', () => {
     describe('when it executes successfully', () => {
       const relationships: Relationship[] = [
         {
           userOneId: userId,
           userTwoId: 'userid-2',
           relationshipType: RelationshipType.Friend,
-          createdAt: new Date()
-        } as Relationship,
+          createdAt: new Date(),
+        },
         {
           userOneId: userId,
           userTwoId: 'userid-3',
           relationshipType: RelationshipType.Friend,
-          createdAt: new Date()
-        } as Relationship
-      ];
-
+          createdAt: new Date(),
+        },
+      ] as Relationship[];
       const user: User = { id: 'userid-2' } as User;
 
       beforeEach(() => {
-        relSvcGetRelationshipsSpy = spyOn(TestBed.inject(RelationshipsService), 'getRelationships')
-          .and.returnValue(of(relationships));
-        usrSvcGetUserSpy = spyOn(TestBed.inject(UsersService), 'getUser')
-          .and.returnValue(of(user));
+        spyOn(TestBed.inject(RelationshipsService), 'getRelationships').and.returnValue(of(relationships));
+        spyOn(TestBed.inject(UsersService), 'getUser').and.returnValue(of(user));
       });
 
       it('should set variable values correctly', () => {
         component.ngOnInit();
-
         expect(component.createConversationRequest.senderId).toEqual(userId);
         expect(component.friends).toEqual([user, user]);
         expect(component.filteredFriends).toEqual([user, user]);
       });
 
-      it('should call RelationshipsService getRelationships correctly', () => {
+      it('should have called RelationshipsService.getRelationships() correctly', () => {
         component.ngOnInit();
-
-        expect(relSvcGetRelationshipsSpy.calls.count()).toEqual(1);
-        expect(relSvcGetRelationshipsSpy.calls.argsFor(0)).toEqual([ userId, RelationshipType.Friend ]);
+        expect(TestBed.get(RelationshipsService).getRelationships).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(RelationshipsService).getRelationships).toHaveBeenCalledWith(
+          userId,
+          RelationshipType.Friend
+        );
       });
 
-      it('should call UsersService getUser correctly', () => {
+      it('should have called UsersService.getUser() correctly', () => {
         component.ngOnInit();
-
-        expect(usrSvcGetUserSpy.calls.count()).toEqual(2);
-        expect(usrSvcGetUserSpy.calls.allArgs()).toEqual([['userid-2'], ['userid-3']]);
+        expect(TestBed.get(UsersService).getUser).toHaveBeenCalledTimes(2);
+        expect(TestBed.get(UsersService).getUser).toHaveBeenCalledWith('userid-2');
+        expect(TestBed.get(UsersService).getUser).toHaveBeenCalledWith('userid-3');
       });
     });
   });

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -1,14 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { MessageComposerComponent } from './message-composer.component';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RelationshipsService } from '../services/relationships.service';
 import { ConversationsService } from '../services/conversations.service';
 import { UsersService } from '../services/users.service';
 import { GlobalHelper } from '../helpers/global';
-import { FormsModule } from '@angular/forms';
 import { AngularMaterialModule } from '../angular-material.module';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('MessageComposerComponent', () => {
   let component: MessageComposerComponent;
@@ -28,17 +28,15 @@ describe('MessageComposerComponent', () => {
       ]
     })
     .compileComponents();
+
+    fixture = TestBed.createComponent(MessageComposerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   afterEach(() => {
     localStorage.removeItem('currentUser');
   })
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(MessageComposerComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -73,7 +73,7 @@ describe('MessageComposerComponent', () => {
       component.friends = friends;
     });
 
-    describe('if the receiver is not a friend', () => {
+    describe('when the receiver is not a friend', () => {
       beforeEach(() => {
         component.createConversationRequest.receiverId = 'userid-3';
       });
@@ -84,7 +84,7 @@ describe('MessageComposerComponent', () => {
       });
     });
 
-    describe('if ConversationsService.createConversation() returns a conflict error', () => {
+    describe('when ConversationsService.createConversation() returns a conflict error', () => {
       const convReq: CreateConversationRequest = new CreateConversationRequest();
       convReq.receiverId = friends[1].id;
       convReq.senderId = userId;
@@ -114,7 +114,7 @@ describe('MessageComposerComponent', () => {
       });
     });
 
-    describe('if it completes successfully', () => {
+    describe('when it completes successfully', () => {
       let convReq: CreateConversationRequest = new CreateConversationRequest();
 
       beforeEach(() => {

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -9,13 +9,19 @@ import { ConversationsService } from '../services/conversations.service';
 import { UsersService } from '../services/users.service';
 import { GlobalHelper } from '../helpers/global';
 import { AngularMaterialModule } from '../angular-material.module';
+import { of } from 'rxjs';
+import { Relationship } from '../models/relationship';
+import { RelationshipType } from '../models/relationship-type.enum';
+import { User } from '../models/user';
 
 describe('MessageComposerComponent', () => {
   let component: MessageComposerComponent;
   let fixture: ComponentFixture<MessageComposerComponent>;
 
+  const userId = 'userid-1'
+
   beforeEach(() => {
-    localStorage.setItem('currentUser', '{ "id": "id" }');
+    localStorage.setItem('currentUser', JSON.stringify({ id: userId }));
     TestBed.configureTestingModule({
       declarations: [ MessageComposerComponent ],
       imports: [HttpClientTestingModule, FormsModule, AngularMaterialModule, BrowserAnimationsModule],
@@ -36,9 +42,58 @@ describe('MessageComposerComponent', () => {
 
   afterEach(() => {
     localStorage.removeItem('currentUser');
-  })
+  });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('ngOnInit', () => {
+    let relSvcGetRelationshipsSpy: jasmine.Spy;
+    let usrSvcGetUserSpy: jasmine.Spy;
+
+    describe('when it executes successfully', () => {
+      const relationships: Relationship[] = [
+        {
+          userOneId: userId,
+          userTwoId: 'userid-2',
+          relationshipType: RelationshipType.Friend,
+          createdAt: new Date()
+        } as Relationship,
+        {
+          userOneId: userId,
+          userTwoId: 'userid-3',
+          relationshipType: RelationshipType.Friend,
+          createdAt: new Date()
+        } as Relationship
+      ];
+
+      const user: User = { id: 'userid-2' } as User;
+
+      beforeEach(() => {
+        relSvcGetRelationshipsSpy = spyOn(TestBed.inject(RelationshipsService), 'getRelationships')
+          .and.returnValue(of(relationships));
+        usrSvcGetUserSpy = spyOn(TestBed.inject(UsersService), 'getUser')
+          .and.returnValue(of(user));
+      });
+
+      it('should set variable values correctly', () => {
+        component.ngOnInit();
+
+        expect(component.createConversationRequest.senderId).toEqual(userId);
+        expect(component.friends).toEqual([user, user]);
+        expect(component.filteredFriends).toEqual([user, user]);
+      });
+
+      it('should call RelationshipsService getRelationships correctly', () => {
+        component.ngOnInit();
+
+        expect(relSvcGetRelationshipsSpy.calls.count()).toEqual(1);
+        expect(relSvcGetRelationshipsSpy.calls.argsFor(0)).toEqual([ userId, RelationshipType.Friend ]);
+      });
+
+      it('should call UsersService getUser correctly', () => {
+        component.ngOnInit();
+
+        expect(usrSvcGetUserSpy.calls.count()).toEqual(2);
+        expect(usrSvcGetUserSpy.calls.allArgs()).toEqual([['userid-2'], ['userid-3']]);
+      });
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -7,7 +7,6 @@ import { MessageComposerComponent } from './message-composer.component';
 import { RelationshipsService } from '../services/relationships.service';
 import { ConversationsService } from '../services/conversations.service';
 import { UsersService } from '../services/users.service';
-import { GlobalHelper } from '../helpers/global';
 import { AngularMaterialModule } from '../angular-material.module';
 import { of, throwError } from 'rxjs';
 import { Relationship } from '../models/relationship';
@@ -32,10 +31,6 @@ describe('MessageComposerComponent', () => {
       declarations: [ MessageComposerComponent ],
       imports: [HttpClientTestingModule, FormsModule, AngularMaterialModule, BrowserAnimationsModule],
       providers: [
-        GlobalHelper,
-        RelationshipsService,
-        ConversationsService,
-        UsersService,
         { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
       ]
     })

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -2,8 +2,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-
 import { of, throwError } from 'rxjs';
+
 import { AngularMaterialModule } from '../angular-material.module';
 import { ConversationsService } from '../services/conversations.service';
 import { CreateConversationRequest } from '../models/requests/create-conversation-request';
@@ -115,13 +115,13 @@ describe('MessageComposerComponent', () => {
     });
 
     describe('when it completes successfully', () => {
-      let convReq: CreateConversationRequest = new CreateConversationRequest();
+      const convReq: CreateConversationRequest = new CreateConversationRequest();
+      convReq.receiverId = friends[1].id;
+      convReq.senderId = userId;
 
       beforeEach(() => {
         component.createConversationRequest.receiverId = friends[1].id;
         TestBed.get(ConversationsService).createConversation.and.returnValue(of('conversationid-1'));
-        convReq.receiverId = friends[1].id;
-        convReq.senderId = userId;
       });
 
       it('should have called ConversationsService.createConversation() correctly', () => {

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.spec.ts
@@ -9,16 +9,22 @@ import { ConversationsService } from '../services/conversations.service';
 import { UsersService } from '../services/users.service';
 import { GlobalHelper } from '../helpers/global';
 import { AngularMaterialModule } from '../angular-material.module';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { Relationship } from '../models/relationship';
 import { RelationshipType } from '../models/relationship-type.enum';
 import { User } from '../models/user';
+import { CreateConversationRequest } from '../models/requests/create-conversation-request';
 
 describe('MessageComposerComponent', () => {
   let component: MessageComposerComponent;
   let fixture: ComponentFixture<MessageComposerComponent>;
 
   const userId = 'userid-1'
+
+  const friends = [
+    { id: 'userid-1', fullName: 'Jack Ryan' } as User,
+    { id: 'userid-2', fullName: 'Tom Cruise' } as User
+  ];
 
   beforeEach(() => {
     localStorage.setItem('currentUser', JSON.stringify({ id: userId }));
@@ -42,6 +48,122 @@ describe('MessageComposerComponent', () => {
 
   afterEach(() => {
     localStorage.removeItem('currentUser');
+  });
+
+  describe('filterFriends', () => {
+    beforeEach(() => {
+      component.filteredFriends = null;
+      component.friends = friends;
+    });
+
+    it('should set filteredFriends correctly', () => {
+      component.filterFriends(' Rya');
+      expect(component.filteredFriends).toEqual([friends[0]]);
+
+      component.filterFriends('om C');
+      expect(component.filteredFriends).toEqual([friends[1]]);
+    });
+  });
+
+  describe('displayFriend', () => {
+    beforeEach(() => {
+      component.friends = friends;
+    });
+
+    it('should return the expected value', () => {
+      const friend = component.displayFriend('userid-2');
+      expect(friend).toEqual('Tom Cruise');
+
+      const nonFriend = component.displayFriend('userid-3');
+      expect(nonFriend).toEqual('Unknown');
+    });
+  });
+
+  describe('sendMessage', () => {
+    let cnvSvcCreateConversationSpy: jasmine.Spy;
+    let conversationReadyEmitSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      cnvSvcCreateConversationSpy = spyOn(TestBed.inject(ConversationsService), 'createConversation')
+      conversationReadyEmitSpy = spyOn(component.conversationReady, 'emit');
+      component.friends = friends;
+    });
+
+    describe('if the receiver is not a friend', () => {
+      beforeEach(() => {
+        component.createConversationRequest.receiverId = 'userid-3';
+      });
+
+      it('should not call ConversationsService createConversation', () => {
+        component.sendMessage();
+
+        expect(cnvSvcCreateConversationSpy.calls.count()).toEqual(0);
+      });
+    });
+
+    describe('if ConversationsService createConversation returns a conflict error', () => {
+      let convReq = new CreateConversationRequest();
+
+      beforeEach(() => {
+        component.createConversationRequest.receiverId = friends[1].id;
+        cnvSvcCreateConversationSpy
+          .and.returnValue(throwError({ status: 409, error: 'conversationid-error' }));
+        convReq.receiverId = friends[1].id;
+        convReq.senderId = userId;
+      });
+
+      it('should call ConversationsService createConversation correctly', () => {
+        component.sendMessage();
+
+        expect(cnvSvcCreateConversationSpy.calls.count()).toEqual(1);
+        expect(cnvSvcCreateConversationSpy.calls.argsFor(0)).toEqual([convReq]);
+      });
+
+      it('should emit a conversationReady event', () => {
+        component.sendMessage();
+
+        expect(conversationReadyEmitSpy.calls.count()).toEqual(1);
+        expect(conversationReadyEmitSpy.calls.argsFor(0)).toEqual(['conversationid-error']);
+      });
+
+      it('should have set variables correctly', () => {
+        component.sendMessage();
+
+        expect(component.loading).toEqual(false);
+      });
+    });
+
+    describe('if it completes successfully', () => {
+      let convReq = new CreateConversationRequest();
+
+      beforeEach(() => {
+        component.createConversationRequest.receiverId = friends[1].id;
+        cnvSvcCreateConversationSpy
+          .and.returnValue(of('conversationid-1'));
+        convReq.receiverId = friends[1].id;
+        convReq.senderId = userId;
+      });
+
+      it('should call ConversationsService createConversation correctly', () => {
+        component.sendMessage();
+
+        expect(cnvSvcCreateConversationSpy.calls.count()).toEqual(1);
+        expect(cnvSvcCreateConversationSpy.calls.argsFor(0)).toEqual([convReq]);
+      });
+
+      it('should emit a conversationReady event', () => {
+        component.sendMessage();
+
+        expect(conversationReadyEmitSpy.calls.count()).toEqual(1);
+        expect(conversationReadyEmitSpy.calls.argsFor(0)).toEqual(['conversationid-1']);
+      });
+
+      it('should have set variables correctly', () => {
+        component.sendMessage();
+
+        expect(component.loading).toEqual(false);
+      });
+    });
   });
 
   describe('ngOnInit', () => {

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.ts
@@ -74,8 +74,9 @@ export class MessageComposerComponent implements OnInit {
     });
   }
 
-  public displayFriend(userId: string) {
-    return this.friends.find(friend => friend.id === userId).fullName;
+  public displayFriend(userId: string): string {
+    const friend = this.friends.find(friend => friend.id === userId);
+    return friend ? friend.fullName : "Unknown";
   }
 
   public filterFriends(name: string): void {

--- a/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/message-composer/message-composer.component.ts
@@ -75,6 +75,8 @@ export class MessageComposerComponent implements OnInit {
   }
 
   public displayFriend(userId: string): string {
+    if (!userId) return;
+    
     const friend = this.friends.find(friend => friend.id === userId);
     return friend ? friend.fullName : "Unknown";
   }

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
@@ -129,6 +129,18 @@ describe('MessagesComponent', () => {
     beforeEach(() => {
       cnvSvcGetConversationsSpy = spyOn(TestBed.inject(ConversationsService), 'getConversations');
       component.conversations = conversations;
+
+      let cnvId = '';
+
+      const setterSpy = spyOnProperty(component.conversation, 'conversationId', 'set')
+        .and.callFake((convId: string) => {
+          cnvId = convId;
+      });
+
+      const getterSpy = spyOnProperty(component.conversation, 'conversationId', 'get')
+        .and.callFake(() => {
+          return cnvId;
+      });
     });
 
     describe('if the conversation has not already been loaded', () => {
@@ -139,7 +151,6 @@ describe('MessagesComponent', () => {
       const convId = unloadedConversation.id;
 
       beforeEach(() => {
-        component.conversation.conversationId = unloadedConversation.id;
         cnvSvcGetConversationsSpy.and.returnValue(of([unloadedConversation]));
         cnvSvcGetConversationParticipantsSpy = spyOn(TestBed.inject(ConversationsService), 'getConversationParticipants')
           .and.returnValue(of([users[0].id, users[1].id]));
@@ -147,6 +158,8 @@ describe('MessagesComponent', () => {
           .and.returnValue(of(users[0]));
         msgSvcGetMessagesFromConversationSpy = spyOn(TestBed.inject(MessagesService), 'getMessagesFromConversation')
           .and.returnValue(of(lastMessages[0]));
+
+        component.conversation.conversationId = unloadedConversation.id;
       });
 
       it('should set variables correctly', () => {
@@ -194,7 +207,7 @@ describe('MessagesComponent', () => {
         component.loadConversation(conversations[0].id);
 
         expect(component.startNewConversation).toEqual(false);
-        //expect(component.conversation.conversationId).toEqual(conversations[0].id);
+        expect(component.conversation.conversationId).toEqual(conversations[0].id);
       });
 
       it('should not call ConversationsService getConversations', () => {

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
@@ -1,34 +1,32 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ProfileComponent } from './profile.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing'; 
+import { ConversationsService } from '../services/conversations.service';
 import { UsersService } from '../services/users.service';
-import { RelationshipsService } from '../services/relationships.service';
 import { GlobalHelper } from '../helpers/global';
-import { RequestsService } from '../services/requests.service';
+import { MessagesComponent } from './messages.component';
+import { MessagesService } from '../services/messages.service';
 
-describe('ProfileComponent', () => {
-  let component: ProfileComponent;
-  let fixture: ComponentFixture<ProfileComponent>;
+describe('MessagesComponent', () => {
+  let component: MessagesComponent;
+  let fixture: ComponentFixture<MessagesComponent>;
 
   beforeEach(() => {
     localStorage.setItem('currentUser', '{ "id": "id" }');
-
     TestBed.configureTestingModule({
-      declarations: [ ProfileComponent ],
-      imports: [HttpClientTestingModule, RouterTestingModule],
+      declarations: [ MessagesComponent ],
+      imports: [HttpClientTestingModule],
       providers: [
-        UsersService,
-        RequestsService,
-        RelationshipsService,
         GlobalHelper,
+        ConversationsService,
+        MessagesService,
+        UsersService,
         { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
       ]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(ProfileComponent);
+    fixture = TestBed.createComponent(MessagesComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
@@ -8,13 +8,54 @@ import { MessagesComponent } from './messages.component';
 import { MessagesService } from '../services/messages.service';
 import { ConversationComponent } from '../conversation/conversation.component';
 import { FormBuilder } from '@angular/forms';
+import { ExtendedConversation } from '../models/conversation';
+import { User } from '../models/user';
+import { FriendlyMessage } from '../models/message';
 
 describe('MessagesComponent', () => {
   let component: MessagesComponent;
   let fixture: ComponentFixture<MessagesComponent>;
 
+  const users = [
+    { id: 'userid-1', fullName: 'Jack Ryan', profilePictureUrl: 'website.com' } as User,
+    { id: 'userid-2', fullName: 'Tom Cruise', profilePictureUrl: 'website.co.uk' } as User,
+    { id: 'userid-3', fullName: 'Leonardo DiCaprio', profilePictureUrl: 'website.org' } as User
+  ];
+
+  const participantsOne = new Map<string, User>();
+  participantsOne.set(users[0].id, users[0]);
+  participantsOne.set(users[1].id, users[1]);
+
+  const participantsTwo = new Map<string, User>();
+  participantsOne.set(users[0].id, users[0]);
+  participantsTwo.set(users[2].id, users[2]);
+
+  const lastMessages = [
+    {
+      senderId: users[0].id,
+      sender: users[0]
+    } as FriendlyMessage,
+    {
+      senderId: users[2].id,
+      sender: users[2]
+    } as FriendlyMessage
+  ];
+
+  const conversations = [
+    { 
+      id: 'conversationid-1',
+      participants: participantsOne,
+      lastMessage: lastMessages[0]
+    } as ExtendedConversation,
+    { 
+      id: 'conversationid-2',
+      participants: participantsTwo,
+      lastMessage: lastMessages[1]
+    } as ExtendedConversation
+  ];
+
   beforeEach(() => {
-    localStorage.setItem('currentUser', '{ "id": "id" }');
+    localStorage.setItem('currentUser', '{ "id": "userid-1" }');
     TestBed.configureTestingModule({
       declarations: [ MessagesComponent, ConversationComponent ],
       imports: [HttpClientTestingModule],
@@ -38,7 +79,61 @@ describe('MessagesComponent', () => {
     localStorage.removeItem('currentUser');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('ngOnInit', () => {
+
+  });
+
+  describe('getConversationName', () => {
+    beforeEach(() => {
+      component.conversations = conversations;
+    });
+
+    it('should return the expected value', () => {
+      const conversationName = component.getConversationName('conversationid-1');
+      
+      expect(conversationName).toEqual('Tom Cruise');
+    });
+  });
+
+  describe('getConversationPicture', () => {
+    beforeEach(() => {
+      component.conversations = conversations;
+    });
+
+    it('should return the expected value', () => {
+      const conversationName = component.getConversationPicture('conversationid-1');
+      
+      expect(conversationName).toEqual('website.co.uk');
+    });
+  });
+
+  describe('getLastMessageSender', () => {
+    beforeEach(() => {
+      component.conversations = conversations;
+    });
+
+    it('should return the expected value', () => {
+      let lastMessageSender = component.getLastMessageSender('conversationid-1');
+      expect(lastMessageSender).toEqual('You');
+
+      lastMessageSender = component.getLastMessageSender('conversationid-2');
+      expect(lastMessageSender).toEqual('Leonardo DiCaprio');
+    });
+  });
+
+  describe('loadConversation', () => {
+
+  });
+
+  describe('showStartConversation', () => {
+    beforeEach(() => {
+      component.startNewConversation = false;
+    });
+
+    it('should set variables correctly', () => {
+      component.showStartConversation();
+
+      expect(component.startNewConversation).toEqual(true);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
@@ -1,77 +1,63 @@
+import { FormBuilder } from '@angular/forms';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { of } from 'rxjs';
+import { ConversationComponent } from '../conversation/conversation.component';
 import { ConversationsService } from '../services/conversations.service';
-import { UsersService } from '../services/users.service';
+import { ExtendedConversation } from '../models/conversation';
+import { FriendlyMessage } from '../models/message';
 import { MessagesComponent } from './messages.component';
 import { MessagesService } from '../services/messages.service';
-import { ConversationComponent } from '../conversation/conversation.component';
-import { FormBuilder } from '@angular/forms';
-import { ExtendedConversation } from '../models/conversation';
 import { User } from '../models/user';
-import { FriendlyMessage } from '../models/message';
-import { of } from 'rxjs';
+import { UsersService } from '../services/users.service';
 
 describe('MessagesComponent', () => {
+  const participantsOne = new Map<string, User>();
+  const participantsTwo = new Map<string, User>();
+  const users: User[] = [
+    { id: 'userid-1', fullName: 'Jack Ryan', profilePictureUrl: 'website.com' },
+    { id: 'userid-2', fullName: 'Tom Cruise', profilePictureUrl: 'website.co.uk' },
+    { id: 'userid-3', fullName: 'Leonardo DiCaprio', profilePictureUrl: 'website.org' },
+  ] as User[];
+  const lastMessages: FriendlyMessage[] = [
+    { senderId: users[0].id, sender: users[0] },
+    { senderId: users[2].id, sender: users[2] },
+  ] as FriendlyMessage[];
+  const conversations: ExtendedConversation[] = [
+    {
+      id: 'conversationid-1',
+      participants: participantsOne,
+      lastMessage: lastMessages[0],
+    },
+    {
+      id: 'conversationid-2',
+      participants: participantsTwo,
+      lastMessage: lastMessages[1],
+    },
+  ] as ExtendedConversation[];
+  const unloadedConversation: ExtendedConversation = {
+    id: 'conversationid-3',
+    participants: participantsOne,
+    lastMessage: lastMessages[0],
+  } as ExtendedConversation;
   let component: MessagesComponent;
   let fixture: ComponentFixture<MessagesComponent>;
 
-  const users = [
-    { id: 'userid-1', fullName: 'Jack Ryan', profilePictureUrl: 'website.com' } as User,
-    { id: 'userid-2', fullName: 'Tom Cruise', profilePictureUrl: 'website.co.uk' } as User,
-    { id: 'userid-3', fullName: 'Leonardo DiCaprio', profilePictureUrl: 'website.org' } as User
-  ];
-
-  const participantsOne = new Map<string, User>();
-  participantsOne.set(users[0].id, users[0]);
-  participantsOne.set(users[1].id, users[1]);
-
-  const participantsTwo = new Map<string, User>();
-  participantsOne.set(users[0].id, users[0]);
-  participantsTwo.set(users[2].id, users[2]);
-
-  const lastMessages = [
-    {
-      senderId: users[0].id,
-      sender: users[0]
-    } as FriendlyMessage,
-    {
-      senderId: users[2].id,
-      sender: users[2]
-    } as FriendlyMessage
-  ];
-
-  const conversations = [
-    { 
-      id: 'conversationid-1',
-      participants: participantsOne,
-      lastMessage: lastMessages[0]
-    } as ExtendedConversation,
-    { 
-      id: 'conversationid-2',
-      participants: participantsTwo,
-      lastMessage: lastMessages[1]
-    } as ExtendedConversation
-  ];
-
-  const unloadedConversation = { 
-      id: 'conversationid-3',
-      participants: participantsOne,
-      lastMessage: lastMessages[0]
-    } as ExtendedConversation;
+  beforeAll(() => {
+    participantsOne.set(users[0].id, users[0]);
+    participantsOne.set(users[1].id, users[1]);
+    participantsOne.set(users[0].id, users[0]);
+    participantsTwo.set(users[2].id, users[2]);
+  });
 
   beforeEach(() => {
     localStorage.setItem('currentUser', JSON.stringify({ id: users[0].id }));
     TestBed.configureTestingModule({
-      declarations: [ MessagesComponent, ConversationComponent ],
+      declarations: [MessagesComponent, ConversationComponent],
       imports: [HttpClientTestingModule],
-      providers: [
-        FormBuilder,
-        { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
-      ]
-    })
-    .compileComponents();
-
+      providers: [FormBuilder, { provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
+    }).compileComponents();
     fixture = TestBed.createComponent(MessagesComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -81,151 +67,109 @@ describe('MessagesComponent', () => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('ngOnInit', () => {
+  describe('ngOnInit()', () => {});
 
-  });
-
-  describe('getConversationName', () => {
-    beforeEach(() => {
+  describe('getConversationName()', () => {
+    it('should have returned the expected value', () => {
       component.conversations = conversations;
-    });
-
-    it('should return the expected value', () => {
       const conversationName = component.getConversationName('conversationid-1');
-      
       expect(conversationName).toEqual('Tom Cruise');
     });
   });
 
-  describe('getConversationPicture', () => {
-    beforeEach(() => {
+  describe('getConversationPicture()', () => {
+    it('should have returned the expected value', () => {
       component.conversations = conversations;
-    });
-
-    it('should return the expected value', () => {
       const conversationName = component.getConversationPicture('conversationid-1');
-      
       expect(conversationName).toEqual('website.co.uk');
     });
   });
 
-  describe('getLastMessageSender', () => {
-    beforeEach(() => {
+  describe('getLastMessageSender()', () => {
+    it('should have returned the expected value', () => {
       component.conversations = conversations;
-    });
-
-    it('should return the expected value', () => {
       let lastMessageSender = component.getLastMessageSender('conversationid-1');
       expect(lastMessageSender).toEqual('You');
-
       lastMessageSender = component.getLastMessageSender('conversationid-2');
       expect(lastMessageSender).toEqual('Leonardo DiCaprio');
     });
   });
 
-  describe('loadConversation', () => {
-    let cnvSvcGetConversationsSpy: jasmine.Spy;
-
+  describe('loadConversation()', () => {
     beforeEach(() => {
-      cnvSvcGetConversationsSpy = spyOn(TestBed.inject(ConversationsService), 'getConversations');
       component.conversations = conversations;
-
       let cnvId = '';
-
-      const setterSpy = spyOnProperty(component.conversation, 'conversationId', 'set')
-        .and.callFake((convId: string) => {
-          cnvId = convId;
+      spyOnProperty(component.conversation, 'conversationId', 'set').and.callFake((convId: string) => {
+        cnvId = convId;
       });
-
-      const getterSpy = spyOnProperty(component.conversation, 'conversationId', 'get')
-        .and.callFake(() => {
-          return cnvId;
+      spyOnProperty(component.conversation, 'conversationId', 'get').and.callFake(() => {
+        return cnvId;
       });
     });
 
     describe('if the conversation has not already been loaded', () => {
-      let cnvSvcGetConversationParticipantsSpy: jasmine.Spy;
-      let usrSvcGetUserSpy: jasmine.Spy;
-      let msgSvcGetMessagesFromConversationSpy: jasmine.Spy;
-
       const convId = unloadedConversation.id;
 
       beforeEach(() => {
-        cnvSvcGetConversationsSpy.and.returnValue(of([unloadedConversation]));
-        cnvSvcGetConversationParticipantsSpy = spyOn(TestBed.inject(ConversationsService), 'getConversationParticipants')
-          .and.returnValue(of([users[0].id, users[1].id]));
-        usrSvcGetUserSpy = spyOn(TestBed.inject(UsersService), 'getUser')
-          .and.returnValue(of(users[0]));
-        msgSvcGetMessagesFromConversationSpy = spyOn(TestBed.inject(MessagesService), 'getMessagesFromConversation')
-          .and.returnValue(of(lastMessages[0]));
-
+        spyOn(TestBed.inject(ConversationsService), 'getConversations').and.returnValue(of([unloadedConversation]));
+        spyOn(TestBed.inject(ConversationsService), 'getConversationParticipants').and.returnValue(
+          of([users[0].id, users[1].id])
+        );
+        spyOn(TestBed.inject(UsersService), 'getUser').and.returnValue(of(users[0]));
+        spyOn(TestBed.inject(MessagesService), 'getMessagesFromConversation').and.returnValue(of(lastMessages[0]));
         component.conversation.conversationId = unloadedConversation.id;
+        component.loadConversation(convId);
       });
 
       it('should set variables correctly', () => {
-        component.loadConversation(convId);
-
         expect(component.startNewConversation).toEqual(false);
         expect(component.conversation.conversationId).toEqual(convId);
         expect(component.conversations).toEqual([unloadedConversation]);
       });
 
-      it('should call ConversationsService getConversations',() => {
-        component.loadConversation(convId);
-
-        expect(cnvSvcGetConversationsSpy.calls.count()).toEqual(1);
-        expect(cnvSvcGetConversationsSpy.calls.argsFor(0)).toEqual([users[0].id]);
+      it('should call ConversationsService.getConversations()', () => {
+        expect(TestBed.get(ConversationsService).getConversations).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(ConversationsService).getConversations).toHaveBeenCalledWith(users[0].id);
       });
 
-      it('should call ConversationsService getConversationParticipants', () => {
-        component.loadConversation(convId);
-
-        expect(cnvSvcGetConversationParticipantsSpy.calls.count()).toEqual(1);
-        expect(cnvSvcGetConversationParticipantsSpy.calls.argsFor(0)).toEqual([unloadedConversation.id]);
+      it('should call ConversationsService.getConversationParticipants()', () => {
+        expect(TestBed.get(ConversationsService).getConversationParticipants).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(ConversationsService).getConversationParticipants).toHaveBeenCalledWith(
+          unloadedConversation.id
+        );
       });
 
-      it('should call UsersService getUser', () => {
-        component.loadConversation(convId);
-
-        expect(usrSvcGetUserSpy.calls.count()).toEqual(2);
-        expect(usrSvcGetUserSpy.calls.argsFor(0)).toEqual([users[0].id]);
-        expect(usrSvcGetUserSpy.calls.argsFor(1)).toEqual([users[1].id]);
+      it('should call UsersService.getUser()', () => {
+        expect(TestBed.get(UsersService).getUser).toHaveBeenCalledTimes(2);
+        expect(TestBed.get(UsersService).getUser).toHaveBeenCalledWith(users[0].id);
+        expect(TestBed.get(UsersService).getUser).toHaveBeenCalledWith(users[1].id);
       });
 
-      it('should call MessagesService getMessagesFromConversation', () => {
-        component.loadConversation(convId);
-
-        expect(msgSvcGetMessagesFromConversationSpy.calls.count()).toEqual(1);
-        expect(msgSvcGetMessagesFromConversationSpy.calls.argsFor(0)).toEqual([
-          convId, 1, 0
-        ]);
+      it('should call MessagesService.getMessagesFromConversation()', () => {
+        expect(TestBed.get(MessagesService).getMessagesFromConversation).toHaveBeenCalledTimes(1);
+        expect(TestBed.get(MessagesService).getMessagesFromConversation).toHaveBeenCalledWith(convId, 1, 0);
       });
     });
 
     describe('if the conversation has already been loaded', () => {
       it('should set variables correctly', () => {
         component.loadConversation(conversations[0].id);
-
         expect(component.startNewConversation).toEqual(false);
         expect(component.conversation.conversationId).toEqual(conversations[0].id);
       });
 
-      it('should not call ConversationsService getConversations', () => {
+      it('should not call ConversationsService.getConversations()', () => {
+        spyOn(TestBed.inject(ConversationsService), 'getConversations');
         component.loadConversation(conversations[0].id);
-
-        expect(cnvSvcGetConversationsSpy.calls.count()).toEqual(0);
+        expect(TestBed.get(ConversationsService).getConversations).toHaveBeenCalledTimes(0);
       });
     });
   });
 
-  describe('showStartConversation', () => {
-    beforeEach(() => {
-      component.startNewConversation = false;
-    });
-
+  describe('showStartConversation()', () => {
     it('should set variables correctly', () => {
+      component.startNewConversation = false;
       component.showStartConversation();
-
       expect(component.startNewConversation).toEqual(true);
     });
   });

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
@@ -1,9 +1,8 @@
 import { FormBuilder } from '@angular/forms';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-
 import { of } from 'rxjs';
-import { getTestScheduler } from 'jasmine-marbles';
+
 import { ConversationComponent } from '../conversation/conversation.component';
 import { ConversationsService } from '../services/conversations.service';
 import { ExtendedConversation, Conversation } from '../models/conversation';
@@ -14,8 +13,8 @@ import { User } from '../models/user';
 import { UsersService } from '../services/users.service';
 
 describe('MessagesComponent', () => {
-  const participantsOne = new Map<string, User>();
-  const participantsTwo = new Map<string, User>();
+  const participantsOne: Map<string, User> = new Map<string, User>();
+  const participantsTwo: Map<string, User> = new Map<string, User>();
   const users: User[] = [
     { id: 'userid-1', fullName: 'Jack Ryan', profilePictureUrl: 'website.com' },
     { id: 'userid-2', fullName: 'Tom Cruise', profilePictureUrl: 'website.co.uk' },
@@ -73,7 +72,6 @@ describe('MessagesComponent', () => {
 
     it('should have returned the expected value', () => {
       const conversationName = component.getConversationName('conversationid-1');
-
       expect(conversationName).toEqual('Tom Cruise');
     });
   });
@@ -92,7 +90,7 @@ describe('MessagesComponent', () => {
   describe('getLastMessageSender()', () => {
     it('should have returned the expected value', () => {
       component.conversations = conversations;
-      let lastMessageSender = component.getLastMessageSender('conversationid-1');
+      let lastMessageSender: string = component.getLastMessageSender('conversationid-1');
       expect(lastMessageSender).toEqual('You');
       lastMessageSender = component.getLastMessageSender('conversationid-2');
       expect(lastMessageSender).toEqual('Leonardo DiCaprio');
@@ -102,7 +100,7 @@ describe('MessagesComponent', () => {
   describe('loadConversation()', () => {
     beforeEach(() => {
       component.conversations = conversations;
-      let cnvId = '';
+      let cnvId: string = '';
       spyOnProperty(component.conversation, 'conversationId', 'set').and.callFake((convId: string) => {
         cnvId = convId;
       });

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
@@ -6,6 +6,8 @@ import { UsersService } from '../services/users.service';
 import { GlobalHelper } from '../helpers/global';
 import { MessagesComponent } from './messages.component';
 import { MessagesService } from '../services/messages.service';
+import { ConversationComponent } from '../conversation/conversation.component';
+import { FormBuilder } from '@angular/forms';
 
 describe('MessagesComponent', () => {
   let component: MessagesComponent;
@@ -14,13 +16,14 @@ describe('MessagesComponent', () => {
   beforeEach(() => {
     localStorage.setItem('currentUser', '{ "id": "id" }');
     TestBed.configureTestingModule({
-      declarations: [ MessagesComponent ],
+      declarations: [ MessagesComponent, ConversationComponent ],
       imports: [HttpClientTestingModule],
       providers: [
         GlobalHelper,
         ConversationsService,
         MessagesService,
         UsersService,
+        FormBuilder,
         { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
       ]
     })

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ConversationsService } from '../services/conversations.service';
 import { UsersService } from '../services/users.service';
-import { GlobalHelper } from '../helpers/global';
 import { MessagesComponent } from './messages.component';
 import { MessagesService } from '../services/messages.service';
 import { ConversationComponent } from '../conversation/conversation.component';
@@ -67,10 +66,6 @@ describe('MessagesComponent', () => {
       declarations: [ MessagesComponent, ConversationComponent ],
       imports: [HttpClientTestingModule],
       providers: [
-        GlobalHelper,
-        ConversationsService,
-        MessagesService,
-        UsersService,
         FormBuilder,
         { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
       ]

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.ts
@@ -33,6 +33,7 @@ export class MessagesComponent implements OnInit {
     private usersService: UsersService) { }
 
   ngOnInit() {
+    debugger;
     this.fetchConversationsData();
   }
 

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.ts
@@ -33,7 +33,6 @@ export class MessagesComponent implements OnInit {
     private usersService: UsersService) { }
 
   ngOnInit() {
-    debugger;
     this.fetchConversationsData();
   }
 

--- a/src/Smp.Web/ClientApp/src/app/messages/messages.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/messages/messages.component.ts
@@ -4,7 +4,7 @@ import { GlobalHelper } from '../helpers/global';
 import { ConversationsService } from '../services/conversations.service';
 import { MessagesService } from '../services/messages.service';
 import { CurrentUser } from '../models/current-user';
-import { Message, FriendlyMessage } from '../models/message';
+import { FriendlyMessage } from '../models/message';
 import { UsersService } from '../services/users.service';
 import { User } from '../models/user';
 import { ConversationComponent } from '../conversation/conversation.component';

--- a/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { NavFooterComponent } from "./nav-footer.component";
+
+describe("NavFooterComponent", () => {
+  let component: NavFooterComponent;
+  let fixture: ComponentFixture<NavFooterComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [NavFooterComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NavFooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
@@ -1,18 +1,26 @@
 import { TestBed, ComponentFixture } from "@angular/core/testing";
 import { NavFooterComponent } from "./nav-footer.component";
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe("NavFooterComponent", () => {
   let component: NavFooterComponent;
   let fixture: ComponentFixture<NavFooterComponent>;
 
   beforeEach(() => {
+    localStorage.setItem('currentUser', '{ "id": "id" }');
+
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
       declarations: [NavFooterComponent],
     }).compileComponents();
     fixture = TestBed.createComponent(NavFooterComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+
+  afterEach(() => {
+    localStorage.removeItem('currentUser');
+  })
 
   it("should create", () => {
     expect(component).toBeTruthy();

--- a/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NavFooterComponent } from './nav-footer.component';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { NavFooterComponent } from './nav-footer.component';
 
 describe('NavFooterComponent', () => {
   let component: NavFooterComponent;

--- a/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/nav-footer/nav-footer.component.spec.ts
@@ -1,14 +1,13 @@
-import { TestBed, ComponentFixture } from "@angular/core/testing";
-import { NavFooterComponent } from "./nav-footer.component";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavFooterComponent } from './nav-footer.component';
 import { RouterTestingModule } from '@angular/router/testing';
 
-describe("NavFooterComponent", () => {
+describe('NavFooterComponent', () => {
   let component: NavFooterComponent;
   let fixture: ComponentFixture<NavFooterComponent>;
 
   beforeEach(() => {
     localStorage.setItem('currentUser', '{ "id": "id" }');
-
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
       declarations: [NavFooterComponent],
@@ -20,9 +19,9 @@ describe("NavFooterComponent", () => {
 
   afterEach(() => {
     localStorage.removeItem('currentUser');
-  })
+  });
 
-  it("should create", () => {
+  it('should have been created', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { GlobalHelper } from '../helpers/global';
 import { ProfileComponent } from './profile.component';
 import { RelationshipsService } from '../services/relationships.service';
@@ -48,29 +48,82 @@ describe('ProfileComponent', () => {
   });
 
   describe('ngOnInit', () => {
-    it("should show 'Add Friend' button", () => {
-      const requestsServiceGetRequestSpy = spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(
-        throwError({ status: 404 })
-      );
-      const relationshipsServiceGetRelationshipSpy = spyOn(
-        TestBed.get(RelationshipsService),
-        'getRelationship'
-      ).and.returnValue(throwError(new Error()));
-      component.ngOnInit();
-      expect(component.showAddFriendButton).toBeTruthy();
-      expect(component.friends).toBeFalsy();
-      expect(requestsServiceGetRequestSpy.calls.count()).toEqual(1);
-      expect(requestsServiceGetRequestSpy.calls.argsFor(0)).toEqual([
-        JSON.parse(localStorage.getItem('currentUser')).id,
-        'bob',
-        RequestType.Friend,
-      ]);
-      expect(relationshipsServiceGetRelationshipSpy.calls.count()).toEqual(1);
-      expect(relationshipsServiceGetRelationshipSpy.calls.argsFor(0)).toEqual([
-        'bob',
-        JSON.parse(localStorage.getItem('currentUser')).id,
-        RequestType.Friend,
-      ]);
+    let requestsServiceGetRequestSpy: jasmine.Spy;
+    let relationshipsServiceGetRelationshipSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      requestsServiceGetRequestSpy = spyOn(TestBed.get(RequestsService), 'getRequest');
+      relationshipsServiceGetRelationshipSpy = spyOn(TestBed.get(RelationshipsService), 'getRelationship');
+    });
+
+    describe("should show 'Add Friend' button", () => {
+      afterEach(() => {
+        expect(component.showAddFriendButton).toBeTruthy();
+        expect(component.friends).toBeFalsy();
+        expect(component.requestPending).toBeFalsy();
+        expect(requestsServiceGetRequestSpy.calls.count()).toEqual(1);
+        expect(requestsServiceGetRequestSpy.calls.argsFor(0)).toEqual(getRequestsServiceGetRequestArgs());
+      });
+
+      it('when RequestsService.getRequest() returns error other than 404', () => {
+        requestsServiceGetRequestSpy.and.returnValue(throwError({ status: 400 }));
+        component.ngOnInit();
+      });
+
+      it('when RequestsService.getRequest() returns 404 error', () => {
+        requestsServiceGetRequestSpy.and.returnValue(throwError({ status: 404 }));
+        relationshipsServiceGetRelationshipSpy.and.returnValue(throwError(new Error()));
+        component.ngOnInit();
+        expect(relationshipsServiceGetRelationshipSpy.calls.count()).toEqual(1);
+        expect(relationshipsServiceGetRelationshipSpy.calls.argsFor(0)).toEqual(
+          getRelationshipsServiceGetRelationshipArgs()
+        );
+      });
+    });
+
+    describe("should not show 'Add Friend' button", () => {
+      afterEach(() => {
+        expect(component.showAddFriendButton).toBeFalsy();
+      });
+
+      it('when the user visits their own profile', () => {
+        localStorage.removeItem('currentUser');
+        localStorage.setItem('currentUser', '{ "id": "bob" }');
+        component.ngOnInit();
+      });
+
+      describe('when RequestsService.getRequest()', () => {
+        it('finds a pending friend request', () => {
+          requestsServiceGetRequestSpy.and.returnValue(of({}));
+          component.ngOnInit();
+          expect(component.friends).toBeFalsy();
+          expect(component.requestPending).toBeTruthy();
+          expect(requestsServiceGetRequestSpy.calls.count()).toEqual(1);
+          expect(requestsServiceGetRequestSpy.calls.argsFor(0)).toEqual(getRequestsServiceGetRequestArgs());
+        });
+
+        it('returns 404 error and RelationshipsService.getRelationship() finds a relationship', () => {
+          requestsServiceGetRequestSpy.and.returnValue(throwError({ status: 404 }));
+          relationshipsServiceGetRelationshipSpy.and.returnValue(of({}));
+          component.ngOnInit();
+          expect(component.friends).toBeTruthy();
+          expect(component.requestPending).toBeFalsy();
+          expect(requestsServiceGetRequestSpy.calls.count()).toEqual(1);
+          expect(requestsServiceGetRequestSpy.calls.argsFor(0)).toEqual(getRequestsServiceGetRequestArgs());
+          expect(relationshipsServiceGetRelationshipSpy.calls.count()).toEqual(1);
+          expect(relationshipsServiceGetRelationshipSpy.calls.argsFor(0)).toEqual(
+            getRelationshipsServiceGetRelationshipArgs()
+          );
+        });
+      });
     });
   });
 });
+
+function getRequestsServiceGetRequestArgs(): Array<any> {
+  return [JSON.parse(localStorage.getItem('currentUser')).id, 'bob', RequestType.Friend];
+}
+
+function getRelationshipsServiceGetRelationshipArgs(): Array<any> {
+  return ['bob', JSON.parse(localStorage.getItem('currentUser')).id, RequestType.Friend];
+}

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -52,18 +52,14 @@ describe('ProfileComponent', () => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('ngOnInit', () => {
+  describe('ngOnInit()', () => {
     let getRequestsServiceGetRequestArgs: Array<any>;
     let getRelationshipsServiceGetRelationshipArgs: Array<any>;
-    let requestsServiceGetRequestSpy: jasmine.Spy;
-    let relationshipsServiceGetRelationshipSpy: jasmine.Spy;
 
     beforeEach(() => {
       const currentUserId = JSON.parse(localStorage.getItem('currentUser')).id;
       getRequestsServiceGetRequestArgs = [currentUserId, 'bob', RequestType.Friend];
       getRelationshipsServiceGetRelationshipArgs = ['bob', currentUserId, RequestType.Friend];
-      requestsServiceGetRequestSpy = spyOn(TestBed.get(RequestsService), 'getRequest');
-      relationshipsServiceGetRelationshipSpy = spyOn(TestBed.get(RelationshipsService), 'getRelationship');
     });
 
     describe("should have shown 'Add Friend' button", () => {
@@ -76,13 +72,13 @@ describe('ProfileComponent', () => {
       });
 
       it('when RequestsService.getRequest() returned error other than 404', () => {
-        requestsServiceGetRequestSpy.and.returnValue(throwError({ status: 321 }));
+        spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(throwError({ status: 321 }));
         component.ngOnInit();
       });
 
       it('when RequestsService.getRequest() returned 404 error', () => {
-        requestsServiceGetRequestSpy.and.returnValue(throwError({ status: 404 }));
-        relationshipsServiceGetRelationshipSpy.and.returnValue(throwError(new Error()));
+        spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(throwError({ status: 404 }));
+        spyOn(TestBed.get(RelationshipsService), 'getRelationship').and.returnValue(throwError(new Error()));
         component.ngOnInit();
         expect(TestBed.get(RelationshipsService).getRelationship).toHaveBeenCalledTimes(1);
         expect(TestBed.get(RelationshipsService).getRelationship).toHaveBeenCalledWith(
@@ -109,15 +105,15 @@ describe('ProfileComponent', () => {
         });
 
         it('found a pending friend request', () => {
-          requestsServiceGetRequestSpy.and.returnValue(of({}));
+          spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(of({}));
           component.ngOnInit();
           expect(component.friends).toBeFalsy();
           expect(component.requestPending).toBeTruthy();
         });
 
         it('returned 404 error and RelationshipsService.getRelationship() found a relationship', () => {
-          requestsServiceGetRequestSpy.and.returnValue(throwError({ status: 404 }));
-          relationshipsServiceGetRelationshipSpy.and.returnValue(of({}));
+          spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(throwError({ status: 404 }));
+          spyOn(TestBed.get(RelationshipsService), 'getRelationship').and.returnValue(of({}));
           component.ngOnInit();
           expect(component.friends).toBeTruthy();
           expect(component.requestPending).toBeFalsy();
@@ -129,10 +125,7 @@ describe('ProfileComponent', () => {
       });
 
       describe('UsersService.getUser()', () => {
-        let usersServiceGetUserSpy: jasmine.Spy;
-
         beforeEach(() => {
-          usersServiceGetUserSpy = spyOn(TestBed.get(UsersService), 'getUser');
           // Skip the logic around the 'Add Friend' button
           localStorage.removeItem('currentUser');
           localStorage.setItem('currentUser', '{ "id": "bob" }');
@@ -144,13 +137,13 @@ describe('ProfileComponent', () => {
         });
 
         it("should have set the 'user' field correctly", () => {
-          usersServiceGetUserSpy.and.callFake(() => of(userMock));
+          spyOn(TestBed.get(UsersService), 'getUser').and.callFake(() => of(userMock));
           component.ngOnInit();
           expect(component.user).toEqual(userMock);
         });
 
         it("should not have set the 'user' field on error", () => {
-          usersServiceGetUserSpy.and.callFake(() => throwError(new Error()));
+          spyOn(TestBed.get(UsersService), 'getUser').and.callFake(() => throwError(new Error()));
           component.ngOnInit();
           expect(component.user).toBeUndefined();
         });

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -13,8 +13,9 @@ import { RequestsService } from '../services/requests.service';
 import { User } from '../models/user';
 import { UsersService } from '../services/users.service';
 import { RequestType } from '../models/request-type.enum';
+import { BrowserModule } from '@angular/platform-browser';
 
-describe('ProfileComponent', () => {
+fdescribe('ProfileComponent', () => {
   const userMock: User = {
     id: 'aknfdkanjdf-123213-asdfdfas',
     fullName: 'bob',
@@ -27,6 +28,7 @@ describe('ProfileComponent', () => {
   beforeEach(() => {
     localStorage.setItem('currentUser', '{ "id": "id" }');
     TestBed.configureTestingModule({
+      declarations: [ProfileComponent],
       imports: [HttpClientTestingModule, RouterTestingModule],
       providers: [
         { provide: 'BASE_URL', useValue: 'https://www.smp.org/' },

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -11,6 +11,7 @@ import { RequestsService } from '../services/requests.service';
 import { User } from '../models/user';
 import { UsersService } from '../services/users.service';
 import { RequestType } from '../models/request-type.enum';
+import { CreateRequestRequest } from '../models/requests/create-request-request';
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
@@ -151,6 +152,22 @@ describe('ProfileComponent', () => {
           expect(component.user).toBeUndefined();
         });
       });
+    });
+  });
+
+  describe('addFriend', () => {
+    const req = new CreateRequestRequest('id', 'bob', RequestType.Friend);
+
+    it('should send a friend request', () => {
+      const requestsServiceSendRequestSpy: jasmine.Spy = spyOn(
+        TestBed.get(RequestsService),
+        'sendRequest'
+      ).and.returnValue(of({}));
+      component.addFriend();
+      expect(component.showAddFriendButton).toBeFalsy();
+      expect(component.requestPending).toBeTruthy();
+      expect(requestsServiceSendRequestSpy.calls.count()).toEqual(1);
+      expect(requestsServiceSendRequestSpy.calls.argsFor(0)).toEqual([req]);
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -1,12 +1,15 @@
+import { ActivatedRoute } from '@angular/router';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { ProfileComponent } from './profile.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing'; 
-import { UsersService } from '../services/users.service';
-import { RelationshipsService } from '../services/relationships.service';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { throwError } from 'rxjs';
 import { GlobalHelper } from '../helpers/global';
+import { ProfileComponent } from './profile.component';
+import { RelationshipsService } from '../services/relationships.service';
 import { RequestsService } from '../services/requests.service';
+import { UsersService } from '../services/users.service';
+import { RequestType } from '../models/request-type.enum';
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
@@ -14,20 +17,27 @@ describe('ProfileComponent', () => {
 
   beforeEach(() => {
     localStorage.setItem('currentUser', '{ "id": "id" }');
-
     TestBed.configureTestingModule({
-      declarations: [ ProfileComponent ],
+      declarations: [ProfileComponent],
       imports: [HttpClientTestingModule, RouterTestingModule],
       providers: [
         UsersService,
         RequestsService,
         RelationshipsService,
         GlobalHelper,
-        { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
-      ]
-    })
-    .compileComponents();
-
+        { provide: 'BASE_URL', useValue: 'https://www.smp.org/' },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: anyArg => 'bob',
+              },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
     fixture = TestBed.createComponent(ProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -37,7 +47,30 @@ describe('ProfileComponent', () => {
     localStorage.removeItem('currentUser');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('ngOnInit', () => {
+    it("should show 'Add Friend' button", () => {
+      const requestsServiceGetRequestSpy = spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(
+        throwError({ status: 404 })
+      );
+      const relationshipsServiceGetRelationshipSpy = spyOn(
+        TestBed.get(RelationshipsService),
+        'getRelationship'
+      ).and.returnValue(throwError(new Error()));
+      component.ngOnInit();
+      expect(component.showAddFriendButton).toBeTruthy();
+      expect(component.friends).toBeFalsy();
+      expect(requestsServiceGetRequestSpy.calls.count()).toEqual(1);
+      expect(requestsServiceGetRequestSpy.calls.argsFor(0)).toEqual([
+        JSON.parse(localStorage.getItem('currentUser')).id,
+        'bob',
+        RequestType.Friend,
+      ]);
+      expect(relationshipsServiceGetRelationshipSpy.calls.count()).toEqual(1);
+      expect(relationshipsServiceGetRelationshipSpy.calls.argsFor(0)).toEqual([
+        'bob',
+        JSON.parse(localStorage.getItem('currentUser')).id,
+        RequestType.Friend,
+      ]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -144,13 +144,13 @@ describe('ProfileComponent', () => {
         });
 
         it("should have set the 'user' field correctly", () => {
-          usersServiceGetUserSpy.and.callFake(userId => of(userMock));
+          usersServiceGetUserSpy.and.callFake(() => of(userMock));
           component.ngOnInit();
           expect(component.user).toEqual(userMock);
         });
 
         it("should not have set the 'user' field on error", () => {
-          usersServiceGetUserSpy.and.callFake(userId => throwError(new Error()));
+          usersServiceGetUserSpy.and.callFake(() => throwError(new Error()));
           component.ngOnInit();
           expect(component.user).toBeUndefined();
         });

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -13,9 +13,8 @@ import { RequestsService } from '../services/requests.service';
 import { User } from '../models/user';
 import { UsersService } from '../services/users.service';
 import { RequestType } from '../models/request-type.enum';
-import { BrowserModule } from '@angular/platform-browser';
 
-fdescribe('ProfileComponent', () => {
+describe('ProfileComponent', () => {
   const userMock: User = {
     id: 'aknfdkanjdf-123213-asdfdfas',
     fullName: 'bob',

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -8,6 +8,7 @@ import { GlobalHelper } from '../helpers/global';
 import { ProfileComponent } from './profile.component';
 import { RelationshipsService } from '../services/relationships.service';
 import { RequestsService } from '../services/requests.service';
+import { User } from '../models/user';
 import { UsersService } from '../services/users.service';
 import { RequestType } from '../models/request-type.enum';
 
@@ -114,6 +115,40 @@ describe('ProfileComponent', () => {
           expect(relationshipsServiceGetRelationshipSpy.calls.argsFor(0)).toEqual(
             getRelationshipsServiceGetRelationshipArgs()
           );
+        });
+      });
+
+      describe('UsersService.getUser()', () => {
+        const userMock: User = {
+          id: 'aknfdkanjdf-123213-asdfdfas',
+          fullName: 'bob',
+          email: 'my@email.com',
+          profilePictureUrl: 'example.com/pics/pic.png',
+        } as User;
+        let usersServiceGetUserSpy: jasmine.Spy;
+
+        beforeEach(() => {
+          usersServiceGetUserSpy = spyOn(TestBed.get(UsersService), 'getUser');
+          // Skip the logic around the 'Add Friend' button
+          localStorage.removeItem('currentUser');
+          localStorage.setItem('currentUser', '{ "id": "bob" }');
+        });
+
+        afterEach(() => {
+          expect(usersServiceGetUserSpy.calls.count()).toEqual(1);
+          expect(usersServiceGetUserSpy.calls.argsFor(0)).toEqual(['bob']);
+        });
+
+        it("should set the 'user' field correctly", () => {
+          usersServiceGetUserSpy.and.returnValue(of(userMock));
+          component.ngOnInit();
+          expect(component.user).toEqual(userMock);
+        });
+
+        it("should not set the 'user' field on error", () => {
+          usersServiceGetUserSpy.and.returnValue(throwError(new Error()));
+          component.ngOnInit();
+          expect(component.user).toBeUndefined();
         });
       });
     });

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.spec.ts
@@ -2,8 +2,8 @@ import { ActivatedRoute } from '@angular/router';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { of, throwError } from 'rxjs';
+
 import { CreateRequestRequest } from '../models/requests/create-request-request';
 import { FeedComponent } from '../feed/feed.component';
 import { PostsService } from '../services/posts.service';
@@ -104,14 +104,14 @@ describe('ProfileComponent', () => {
           expect(TestBed.get(RequestsService).getRequest).toHaveBeenCalledWith(...getRequestsServiceGetRequestArgs);
         });
 
-        it('found a pending friend request', () => {
+        it('should have found a pending friend request', () => {
           spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(of({}));
           component.ngOnInit();
           expect(component.friends).toBeFalsy();
           expect(component.requestPending).toBeTruthy();
         });
 
-        it('returned 404 error and RelationshipsService.getRelationship() found a relationship', () => {
+        it('should have returned 404 error and RelationshipsService.getRelationship() found a relationship', () => {
           spyOn(TestBed.get(RequestsService), 'getRequest').and.returnValue(throwError({ status: 404 }));
           spyOn(TestBed.get(RelationshipsService), 'getRelationship').and.returnValue(of({}));
           component.ngOnInit();

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.ts
@@ -66,7 +66,6 @@ export class ProfileComponent implements OnInit {
         this.user = result;
       },
       error: (error: any) => {
-        console.error(error);
       },
     });
   }

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.ts
@@ -1,15 +1,16 @@
-import { Component, OnInit, NgZone, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { User } from '../models/user';
-import { UsersService } from '../services/users.service';
+import { Component, OnInit, ViewChild } from '@angular/core';
+
+import { CreateRequestRequest } from '../models/requests/create-request-request';
+import { CurrentUser } from '../models/current-user';
 import { FeedComponent } from '../feed/feed.component';
 import { GlobalHelper } from '../helpers/global';
-import { CurrentUser } from '../models/current-user';
-import { RequestsService } from '../services/requests.service';
-import { CreateRequestRequest } from '../models/requests/create-request-request';
-import { RequestType } from '../models/request-type.enum';
-import { RelationshipsService } from '../services/relationships.service';
 import { RelationshipType } from '../models/relationship-type.enum';
+import { RelationshipsService } from '../services/relationships.service';
+import { RequestType } from '../models/request-type.enum';
+import { RequestsService } from '../services/requests.service';
+import { User } from '../models/user';
+import { UsersService } from '../services/users.service';
 
 @Component({
   selector: 'app-profile',
@@ -36,7 +37,7 @@ export class ProfileComponent implements OnInit {
   ) {  }
 
   ngOnInit() {
-    let visitingUserId = this.globalHelper.localStorageItem<CurrentUser>('currentUser').id;
+    const visitingUserId = this.globalHelper.localStorageItem<CurrentUser>('currentUser').id;
     this.userId = this.route.snapshot.paramMap.get('id') ?? visitingUserId;
     this.showAddFriendButton = this.userId != visitingUserId;
 
@@ -52,6 +53,8 @@ export class ProfileComponent implements OnInit {
               next: () => {
                 this.showAddFriendButton = false;
                 this.friends = true;
+              },
+              error: (error: any) => {
               }
             });
           }

--- a/src/Smp.Web/ClientApp/src/app/profile/profile.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/profile/profile.component.ts
@@ -15,7 +15,7 @@ import { UsersService } from '../services/users.service';
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.component.html',
-  styleUrls: ['./profile.component.scss']
+  styleUrls: ['./profile.component.scss'],
 })
 export class ProfileComponent implements OnInit {
   @ViewChild(FeedComponent)
@@ -34,7 +34,7 @@ export class ProfileComponent implements OnInit {
     private relationshipsService: RelationshipsService,
     private globalHelper: GlobalHelper,
     private route: ActivatedRoute
-  ) {  }
+  ) {}
 
   ngOnInit() {
     const visitingUserId = this.globalHelper.localStorageItem<CurrentUser>('currentUser').id;
@@ -54,23 +54,21 @@ export class ProfileComponent implements OnInit {
                 this.showAddFriendButton = false;
                 this.friends = true;
               },
-              error: (error: any) => {
-              }
+              error: (error: any) => {},
             });
           }
-        }
+        },
       });
     }
 
-    this.usersService.getUser(this.userId)
-      .subscribe({
-        next: (result: any) => {
-          this.user = result;
-        },
-        error: (error: any) => {
-          console.error(error);
-        }
-      });
+    this.usersService.getUser(this.userId).subscribe({
+      next: (result: any) => {
+        this.user = result;
+      },
+      error: (error: any) => {
+        console.error(error);
+      },
+    });
   }
 
   public updatePosts(): void {
@@ -78,12 +76,16 @@ export class ProfileComponent implements OnInit {
   }
 
   public addFriend(): void {
-    let req = new CreateRequestRequest(this.globalHelper.localStorageItem<CurrentUser>('currentUser').id, this.userId, RequestType.Friend);
+    const req = new CreateRequestRequest(
+      this.globalHelper.localStorageItem<CurrentUser>('currentUser').id,
+      this.userId,
+      RequestType.Friend
+    );
     this.requestsService.sendRequest(req).subscribe({
       next: () => {
         this.showAddFriendButton = false;
         this.requestPending = true;
-      }
+      },
     });
   }
 }

--- a/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-
 import { of, throwError } from 'rxjs';
+
 import { FriendlyRequest, Request } from '../models/request';
 import { RequestType } from '../models/request-type.enum';
 import { RequestsComponent } from './requests.component';

--- a/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
@@ -1,22 +1,37 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RequestsComponent } from './requests.component';
+import { GlobalHelper } from '../helpers/global';
+import { RequestsService } from '../services/requests.service';
+import { UsersService } from '../services/users.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('RequestsComponent', () => {
   let component: RequestsComponent;
   let fixture: ComponentFixture<RequestsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
+    localStorage.setItem('currentUser', '{ "id": "id" }');
+
     TestBed.configureTestingModule({
-      declarations: [ RequestsComponent ]
+      declarations: [ RequestsComponent ],
+      imports: [HttpClientTestingModule],
+      providers: [
+        GlobalHelper,
+        RequestsService,
+        UsersService,
+        { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
+      ]
     })
     .compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(RequestsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('currentUser');
   });
 
   it('should create', () => {

--- a/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
@@ -21,93 +21,94 @@ describe('RequestsComponent', () => {
   } as FriendlyRequest;
   let component: RequestsComponent;
   let fixture: ComponentFixture<RequestsComponent>;
-  let requestsServiceGetIncomingRequestsSpy: jasmine.Spy;
 
   beforeEach(() => {
     localStorage.setItem('currentUser', '{ "id": "id" }');
     TestBed.configureTestingModule({
       declarations: [RequestsComponent],
       imports: [HttpClientTestingModule],
-      providers: [
-        { provide: 'BASE_URL', useValue: 'https://www.smp.org/' },
-      ],
+      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
     }).compileComponents();
     fixture = TestBed.createComponent(RequestsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    requestsServiceGetIncomingRequestsSpy = spyOn(TestBed.get(RequestsService), 'getIncomingRequests');
   });
 
   afterEach(() => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('ngOnInit', () => {
-    it('should call getRequests', () => {
-      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([]));
+  describe('ngOnInit()', () => {
+    it('should have called getRequests()', () => {
+      spyOn(TestBed.get(RequestsService), 'getIncomingRequests').and.returnValue(of([]));
       component.ngOnInit();
-      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledWith(
+        JSON.parse(localStorage.getItem('currentUser')).id
+      );
     });
   });
 
-  describe('answerRequest', () => {
-    let requestsServiceAcceptRequestSpy: jasmine.Spy;
-    let requestsServiceDeclineRequestSpy: jasmine.Spy;
-
+  describe('answerRequest()', () => {
     beforeEach(() => {
-      requestsServiceAcceptRequestSpy = spyOn(TestBed.get(RequestsService), 'acceptRequest');
-      requestsServiceDeclineRequestSpy = spyOn(TestBed.get(RequestsService), 'declineRequest');
+      spyOn(TestBed.get(RequestsService), 'getIncomingRequests').and.returnValue(of([]));
     });
 
-    it('should not have called getRequest when answer is true and on API error', () => {
-      requestsServiceAcceptRequestSpy.and.returnValue(throwError(new Error()));
+    it('should not have called getRequest() when answer is true and on API error', () => {
+      spyOn(TestBed.get(RequestsService), 'acceptRequest').and.returnValue(throwError(new Error()));
       component.answerRequest(friendlyRequest, true);
-      expect(requestsServiceAcceptRequestSpy.calls.count()).toEqual(1);
-      expect(requestsServiceAcceptRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
-      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(0);
+      expect(TestBed.get(RequestsService).acceptRequest).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).acceptRequest).toHaveBeenCalledWith(friendlyRequest);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledTimes(0);
     });
 
-    it('should not have called getRequest when answer is false and on API error', () => {
-      requestsServiceDeclineRequestSpy.and.returnValue(throwError(new Error()));
+    it('should not have called getRequest() when answer is false and on API error', () => {
+      spyOn(TestBed.get(RequestsService), 'declineRequest').and.returnValue(throwError(new Error()));
       component.answerRequest(friendlyRequest, false);
-      expect(requestsServiceDeclineRequestSpy.calls.count()).toEqual(1);
-      expect(requestsServiceDeclineRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
-      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(0);
+      expect(TestBed.get(RequestsService).declineRequest).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).declineRequest).toHaveBeenCalledWith(friendlyRequest);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledTimes(0);
     });
 
-    it('should have called getRequest when answer is true', () => {
-      requestsServiceAcceptRequestSpy.and.returnValue(of({}));
-      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([]));
-      component.answerRequest(friendlyRequest, true);
-      expect(requestsServiceAcceptRequestSpy.calls.count()).toEqual(1);
-      expect(requestsServiceAcceptRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
-      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
-    });
-
-    it('should have called getRequest when answer is false', () => {
-      requestsServiceDeclineRequestSpy.and.returnValue(of({}));
-      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([]));
-      component.answerRequest(friendlyRequest, false);
-      expect(requestsServiceDeclineRequestSpy.calls.count()).toEqual(1);
-      expect(requestsServiceDeclineRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
-      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
-    });
-  });
-
-  describe('getRequests', () => {
-    const friendlyReq = new Request(req).toFriendlyRequest();
-
-    it('should have called RequestsService.getIncomingRequests and set this.requests', () => {
+    it('should have called getRequest() when answer is true', () => {
       spyOn(TestBed.get(RequestsService), 'acceptRequest').and.returnValue(of({}));
-      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([req, req]));
-      component.answerRequest(friendlyReq, true);
-      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
-      expect(requestsServiceGetIncomingRequestsSpy.calls.argsFor(0)).toEqual(['id']);
-      expect(component.requests).toEqual([friendlyReq, friendlyReq]);
+      component.answerRequest(friendlyRequest, true);
+      expect(TestBed.get(RequestsService).acceptRequest).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).acceptRequest).toHaveBeenCalledWith(friendlyRequest);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledWith(
+        JSON.parse(localStorage.getItem('currentUser')).id
+      );
+    });
+
+    it('should have called getRequest() when answer is false', () => {
+      spyOn(TestBed.get(RequestsService), 'declineRequest').and.returnValue(of({}));
+      component.answerRequest(friendlyRequest, false);
+      expect(TestBed.get(RequestsService).declineRequest).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).declineRequest).toHaveBeenCalledWith(friendlyRequest);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledWith(
+        JSON.parse(localStorage.getItem('currentUser')).id
+      );
     });
   });
 
-  describe('fetchUsers', () => {
+  describe('getRequests()', () => {
+    const friendlyReq: FriendlyRequest = new Request(req).toFriendlyRequest();
+
+    it('should have called RequestsService.getIncomingRequests() and set this.requests', () => {
+      spyOn(TestBed.get(RequestsService), 'acceptRequest').and.returnValue(of({}));
+      spyOn(TestBed.get(RequestsService), 'getIncomingRequests').and.returnValue(of([req, req]));
+      component.answerRequest(friendlyReq, true);
+      expect(component.requests).toEqual([friendlyReq, friendlyReq]);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(RequestsService).getIncomingRequests).toHaveBeenCalledWith(
+        JSON.parse(localStorage.getItem('currentUser')).id
+      );
+    });
+  });
+
+  describe('fetchUsers()', () => {
     const friendlyReq = new Request(req).toFriendlyRequest();
     const user: User = {
       id: 'adjfs-0123',
@@ -116,17 +117,17 @@ describe('RequestsComponent', () => {
       profilePictureUrl: 'http://example.com',
     } as User;
 
-    it('should have called RequestsService.getUser and set receiver and sender', () => {
+    it('should have called RequestsService.getUser() and set receiver and sender', () => {
       spyOn(TestBed.get(RequestsService), 'acceptRequest').and.returnValue(of({}));
-      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([friendlyReq]));
-      const usersServiceGetUserSpy = spyOn(TestBed.get(UsersService), 'getUser').and.returnValue(of(user));
+      spyOn(TestBed.get(RequestsService), 'getIncomingRequests').and.returnValue(of([friendlyReq]));
+      spyOn(TestBed.get(UsersService), 'getUser').and.returnValue(of(user));
       component.answerRequest(friendlyReq, true);
-      expect(usersServiceGetUserSpy.calls.count()).toEqual(2);
       expect(component.requests.length).toEqual(1);
-      expect(usersServiceGetUserSpy.calls.argsFor(0)).toEqual([friendlyReq.receiverId]);
       expect(component.requests[0].receiver).toEqual(user);
-      expect(usersServiceGetUserSpy.calls.argsFor(1)).toEqual([friendlyReq.senderId]);
       expect(component.requests[0].sender).toEqual(user);
+      expect(TestBed.get(UsersService).getUser).toHaveBeenCalledTimes(2);
+      expect(TestBed.get(UsersService).getUser).toHaveBeenCalledWith(friendlyReq.receiverId);
+      expect(TestBed.get(UsersService).getUser).toHaveBeenCalledWith(friendlyReq.senderId);
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
@@ -1,40 +1,136 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { RequestsComponent } from './requests.component';
-import { GlobalHelper } from '../helpers/global';
-import { RequestsService } from '../services/requests.service';
-import { UsersService } from '../services/users.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
+import { of, throwError } from 'rxjs';
+import { FriendlyRequest, Request } from '../models/request';
+import { GlobalHelper } from '../helpers/global';
+import { RequestType } from '../models/request-type.enum';
+import { RequestsComponent } from './requests.component';
+import { RequestsService } from '../services/requests.service';
+import { User } from '../models/user';
+import { UsersService } from '../services/users.service';
+
 describe('RequestsComponent', () => {
+  const req: Request = {
+    receiverId: '12308n-98afsd',
+    senderId: '09xm1-sf9m0d',
+    createdAt: new Date(),
+    requestType: RequestType.Friend,
+  } as Request;
+  const friendlyRequest: FriendlyRequest = {
+    ...req,
+  } as FriendlyRequest;
   let component: RequestsComponent;
   let fixture: ComponentFixture<RequestsComponent>;
+  let requestsServiceGetIncomingRequestsSpy: jasmine.Spy;
 
   beforeEach(() => {
     localStorage.setItem('currentUser', '{ "id": "id" }');
-
     TestBed.configureTestingModule({
-      declarations: [ RequestsComponent ],
+      declarations: [RequestsComponent],
       imports: [HttpClientTestingModule],
       providers: [
         GlobalHelper,
         RequestsService,
         UsersService,
-        { provide: 'BASE_URL', useValue: "https://www.smp.org/" }
-      ]
-    })
-    .compileComponents();
-
+        { provide: 'BASE_URL', useValue: 'https://www.smp.org/' },
+      ],
+    }).compileComponents();
     fixture = TestBed.createComponent(RequestsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    requestsServiceGetIncomingRequestsSpy = spyOn(TestBed.get(RequestsService), 'getIncomingRequests');
   });
 
   afterEach(() => {
     localStorage.removeItem('currentUser');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('ngOnInit', () => {
+    it('should call getRequests', () => {
+      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([]));
+      component.ngOnInit();
+      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
+    });
+  });
+
+  describe('answerRequest', () => {
+    let requestsServiceAcceptRequestSpy: jasmine.Spy;
+    let requestsServiceDeclineRequestSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      requestsServiceAcceptRequestSpy = spyOn(TestBed.get(RequestsService), 'acceptRequest');
+      requestsServiceDeclineRequestSpy = spyOn(TestBed.get(RequestsService), 'declineRequest');
+    });
+
+    it('should not have called getRequest when answer is true and on API error', () => {
+      requestsServiceAcceptRequestSpy.and.returnValue(throwError(new Error()));
+      component.answerRequest(friendlyRequest, true);
+      expect(requestsServiceAcceptRequestSpy.calls.count()).toEqual(1);
+      expect(requestsServiceAcceptRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
+      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(0);
+    });
+
+    it('should not have called getRequest when answer is false and on API error', () => {
+      requestsServiceDeclineRequestSpy.and.returnValue(throwError(new Error()));
+      component.answerRequest(friendlyRequest, false);
+      expect(requestsServiceDeclineRequestSpy.calls.count()).toEqual(1);
+      expect(requestsServiceDeclineRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
+      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(0);
+    });
+
+    it('should have called getRequest when answer is true', () => {
+      requestsServiceAcceptRequestSpy.and.returnValue(of({}));
+      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([]));
+      component.answerRequest(friendlyRequest, true);
+      expect(requestsServiceAcceptRequestSpy.calls.count()).toEqual(1);
+      expect(requestsServiceAcceptRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
+      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
+    });
+
+    it('should have called getRequest when answer is false', () => {
+      requestsServiceDeclineRequestSpy.and.returnValue(of({}));
+      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([]));
+      component.answerRequest(friendlyRequest, false);
+      expect(requestsServiceDeclineRequestSpy.calls.count()).toEqual(1);
+      expect(requestsServiceDeclineRequestSpy.calls.argsFor(0)).toEqual([friendlyRequest]);
+      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
+    });
+  });
+
+  describe('getRequests', () => {
+    const friendlyReq = new Request(req).toFriendlyRequest();
+
+    it('should have called RequestsService.getIncomingRequests and set this.requests', () => {
+      spyOn(TestBed.get(RequestsService), 'acceptRequest').and.returnValue(of({}));
+      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([req, req]));
+      component.answerRequest(friendlyReq, true);
+      expect(requestsServiceGetIncomingRequestsSpy.calls.count()).toEqual(1);
+      expect(requestsServiceGetIncomingRequestsSpy.calls.argsFor(0)).toEqual(['id']);
+      expect(component.requests).toEqual([friendlyReq, friendlyReq]);
+    });
+  });
+
+  describe('fetchUsers', () => {
+    const friendlyReq = new Request(req).toFriendlyRequest();
+    const user: User = {
+      id: 'adjfs-0123',
+      fullName: 'bob',
+      email: 'my@email.com',
+      profilePictureUrl: 'http://example.com',
+    } as User;
+
+    it('should have called RequestsService.getUser and set receiver and sender', () => {
+      spyOn(TestBed.get(RequestsService), 'acceptRequest').and.returnValue(of({}));
+      requestsServiceGetIncomingRequestsSpy.and.returnValue(of([friendlyReq]));
+      const usersServiceGetUserSpy = spyOn(TestBed.get(UsersService), 'getUser').and.returnValue(of(user));
+      component.answerRequest(friendlyReq, true);
+      expect(usersServiceGetUserSpy.calls.count()).toEqual(2);
+      expect(component.requests.length).toEqual(1);
+      expect(usersServiceGetUserSpy.calls.argsFor(0)).toEqual([friendlyReq.receiverId]);
+      expect(component.requests[0].receiver).toEqual(user);
+      expect(usersServiceGetUserSpy.calls.argsFor(1)).toEqual([friendlyReq.senderId]);
+      expect(component.requests[0].sender).toEqual(user);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/requests/requests.component.spec.ts
@@ -3,7 +3,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { of, throwError } from 'rxjs';
 import { FriendlyRequest, Request } from '../models/request';
-import { GlobalHelper } from '../helpers/global';
 import { RequestType } from '../models/request-type.enum';
 import { RequestsComponent } from './requests.component';
 import { RequestsService } from '../services/requests.service';
@@ -30,9 +29,6 @@ describe('RequestsComponent', () => {
       declarations: [RequestsComponent],
       imports: [HttpClientTestingModule],
       providers: [
-        GlobalHelper,
-        RequestsService,
-        UsersService,
         { provide: 'BASE_URL', useValue: 'https://www.smp.org/' },
       ],
     }).compileComponents();

--- a/src/Smp.Web/ClientApp/src/app/requests/requests.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/requests/requests.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { RequestsService } from '../services/requests.service';
-import { Request, FriendlyRequest } from '../models/request';
-import { GlobalHelper } from '../helpers/global';
+
 import { CurrentUser } from '../models/current-user';
+import { FriendlyRequest, Request } from '../models/request';
+import { GlobalHelper } from '../helpers/global';
+import { RequestsService } from '../services/requests.service';
 import { UsersService } from '../services/users.service';
 
 @Component({

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
@@ -36,43 +36,43 @@ describe('ResetPasswordComponent', () => {
     fixture.detectChanges();
   });
 
-  describe('ngOnInit', () => {
-    it('should get correct actionId', () => {
+  describe('ngOnInit()', () => {
+    it('should have gotten the correct actionId', () => {
       expect(component.resetPasswordRequest.actionId).toEqual('bob');
     });
   });
 
-  describe('resetPassword', () => {
+  describe('resetPassword()', () => {
     const req: ResetPasswordRequest = {
       actionId: '1', // ActionType.ResetPassword
       newPassword: 'qwerty',
       confirmNewPassword: 'qwerty',
     } as ResetPasswordRequest;
-    let accountsServiceCreateUserSpy: jasmine.Spy;
+    let accountsServiceResetPasswordSpy: jasmine.Spy;
 
     beforeEach(() => {
       component.resetPasswordRequest = req;
-      accountsServiceCreateUserSpy = spyOn(TestBed.get(AccountsService), 'resetPassword');
+      accountsServiceResetPasswordSpy = spyOn(TestBed.get(AccountsService), 'resetPassword');
     });
 
-    it('should have a validation error coming from the API', () => {
-      const error = new Error('Descriptive error message.');
-      accountsServiceCreateUserSpy.and.returnValue(throwError({ error }));
+    it('should have stored a validation error coming from the API', () => {
+      const error: Error = new Error('Descriptive error message.');
+      accountsServiceResetPasswordSpy.and.returnValue(throwError({ error }));
       component.resetPassword();
-      expect(accountsServiceCreateUserSpy.calls.count()).toEqual(1);
-      expect(accountsServiceCreateUserSpy.calls.argsFor(0)).toEqual([req]);
       expect(component.validationErrors.length).toEqual(1);
       expect(component.validationErrors[0]).toEqual(error);
       expect(component.resetPasswordSuccessful).toBeFalsy();
+      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledWith(req);
     });
 
-    it('should successfully reset a password', () => {
-      accountsServiceCreateUserSpy.and.returnValue(of({}));
+    it('should have successfully reset a password', () => {
+      accountsServiceResetPasswordSpy.and.returnValue(of({}));
       component.resetPassword();
-      expect(accountsServiceCreateUserSpy.calls.count()).toEqual(1);
-      expect(accountsServiceCreateUserSpy.calls.argsFor(0)).toEqual([req]);
       expect(component.validationErrors.length).toEqual(0);
       expect(component.resetPasswordSuccessful).toBeTruthy();
+      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledWith(req);
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
@@ -18,7 +18,6 @@ describe('ResetPasswordComponent', () => {
       declarations: [ResetPasswordComponent],
       imports: [HttpClientTestingModule, RouterTestingModule, FormsModule],
       providers: [
-        AccountsService,
         { provide: 'BASE_URL', useValue: 'https://www.smp.org/' },
         {
           provide: ActivatedRoute,

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
@@ -1,3 +1,4 @@
+import { ActivatedRoute } from '@angular/router';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -16,25 +17,48 @@ describe('ResetPasswordComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ResetPasswordComponent],
       imports: [HttpClientTestingModule, RouterTestingModule, FormsModule],
-      providers: [AccountsService, { provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
+      providers: [
+        AccountsService,
+        { provide: 'BASE_URL', useValue: 'https://www.smp.org/' },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: anyArg => 'bob',
+              },
+            },
+          },
+        },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(ResetPasswordComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  describe('resetPassword', async () => {
-    const accountsServiceCreateUserSpy: jasmine.Spy = spyOn(TestBed.get(AccountsService), 'resetPassword');
+  describe('ngOnInit', () => {
+    it('should get correct actionId', () => {
+      expect(component.resetPasswordRequest.actionId).toEqual('bob');
+    });
+  });
+
+  describe('resetPassword', () => {
     const req: ResetPasswordRequest = {
       actionId: '1', // ActionType.ResetPassword
       newPassword: 'qwerty',
       confirmNewPassword: 'qwerty',
     } as ResetPasswordRequest;
+    let accountsServiceCreateUserSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      component.resetPasswordRequest = req;
+      accountsServiceCreateUserSpy = spyOn(TestBed.get(AccountsService), 'resetPassword');
+    });
 
     it('should have a validation error coming from the API', () => {
       const error = new Error('Descriptive error message.');
       accountsServiceCreateUserSpy.and.returnValue(throwError({ error }));
-      component.resetPasswordRequest = req;
       component.resetPassword();
       expect(accountsServiceCreateUserSpy.calls.count()).toEqual(1);
       expect(accountsServiceCreateUserSpy.calls.argsFor(0)).toEqual([req]);
@@ -45,7 +69,6 @@ describe('ResetPasswordComponent', () => {
 
     it('should successfully reset a password', () => {
       accountsServiceCreateUserSpy.and.returnValue(of({}));
-      component.resetPasswordRequest = req;
       component.resetPassword();
       expect(accountsServiceCreateUserSpy.calls.count()).toEqual(1);
       expect(accountsServiceCreateUserSpy.calls.argsFor(0)).toEqual([req]);

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { of, throwError } from 'rxjs';
+
 import { AccountsService } from '../services/accounts.service';
 import { ResetPasswordComponent } from './reset-password.component';
 import { ResetPasswordRequest } from '../models/requests/reset-password-request';
@@ -48,31 +48,31 @@ describe('ResetPasswordComponent', () => {
       newPassword: 'qwerty',
       confirmNewPassword: 'qwerty',
     } as ResetPasswordRequest;
-    let accountsServiceResetPasswordSpy: jasmine.Spy;
 
     beforeEach(() => {
       component.resetPasswordRequest = req;
-      accountsServiceResetPasswordSpy = spyOn(TestBed.get(AccountsService), 'resetPassword');
+      spyOn(TestBed.get(AccountsService), 'resetPassword');
     });
+
+    afterEach(() => {
+      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledWith(req);
+    })
 
     it('should have stored a validation error coming from the API', () => {
       const error: Error = new Error('Descriptive error message.');
-      accountsServiceResetPasswordSpy.and.returnValue(throwError({ error }));
+      TestBed.get(AccountsService).resetPassword.and.returnValue(throwError({ error }));
       component.resetPassword();
       expect(component.validationErrors.length).toEqual(1);
       expect(component.validationErrors[0]).toEqual(error);
       expect(component.resetPasswordSuccessful).toBeFalsy();
-      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledTimes(1);
-      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledWith(req);
     });
 
     it('should have successfully reset a password', () => {
-      accountsServiceResetPasswordSpy.and.returnValue(of({}));
+      TestBed.get(AccountsService).resetPassword.and.returnValue(of({}));
       component.resetPassword();
       expect(component.validationErrors.length).toEqual(0);
       expect(component.resetPasswordSuccessful).toBeTruthy();
-      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledTimes(1);
-      expect(TestBed.get(AccountsService).resetPassword).toHaveBeenCalledWith(req);
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
@@ -1,19 +1,23 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ResetPasswordComponent } from './reset-password.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AccountsService } from '../services/accounts.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule } from '@angular/forms';
 
 describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
   let fixture: ComponentFixture<ResetPasswordComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ ResetPasswordComponent ]
+      declarations: [ ResetPasswordComponent ],
+      imports: [HttpClientTestingModule, RouterTestingModule, FormsModule],
+      providers: [AccountsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
     })
     .compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(ResetPasswordComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.spec.ts
@@ -1,10 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { ResetPasswordComponent } from './reset-password.component';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { AccountsService } from '../services/accounts.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { of, throwError } from 'rxjs';
+import { AccountsService } from '../services/accounts.service';
+import { ResetPasswordComponent } from './reset-password.component';
+import { ResetPasswordRequest } from '../models/requests/reset-password-request';
 
 describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
@@ -12,18 +14,43 @@ describe('ResetPasswordComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ ResetPasswordComponent ],
+      declarations: [ResetPasswordComponent],
       imports: [HttpClientTestingModule, RouterTestingModule, FormsModule],
-      providers: [AccountsService, { provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-    })
-    .compileComponents();
-
+      providers: [AccountsService, { provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
+    }).compileComponents();
     fixture = TestBed.createComponent(ResetPasswordComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('resetPassword', async () => {
+    const accountsServiceCreateUserSpy: jasmine.Spy = spyOn(TestBed.get(AccountsService), 'resetPassword');
+    const req: ResetPasswordRequest = {
+      actionId: '1', // ActionType.ResetPassword
+      newPassword: 'qwerty',
+      confirmNewPassword: 'qwerty',
+    } as ResetPasswordRequest;
+
+    it('should have a validation error coming from the API', () => {
+      const error = new Error('Descriptive error message.');
+      accountsServiceCreateUserSpy.and.returnValue(throwError({ error }));
+      component.resetPasswordRequest = req;
+      component.resetPassword();
+      expect(accountsServiceCreateUserSpy.calls.count()).toEqual(1);
+      expect(accountsServiceCreateUserSpy.calls.argsFor(0)).toEqual([req]);
+      expect(component.validationErrors.length).toEqual(1);
+      expect(component.validationErrors[0]).toEqual(error);
+      expect(component.resetPasswordSuccessful).toBeFalsy();
+    });
+
+    it('should successfully reset a password', () => {
+      accountsServiceCreateUserSpy.and.returnValue(of({}));
+      component.resetPasswordRequest = req;
+      component.resetPassword();
+      expect(accountsServiceCreateUserSpy.calls.count()).toEqual(1);
+      expect(accountsServiceCreateUserSpy.calls.argsFor(0)).toEqual([req]);
+      expect(component.validationErrors.length).toEqual(0);
+      expect(component.resetPasswordSuccessful).toBeTruthy();
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
 import { AccountsService } from '../services/accounts.service';
 import { ResetPasswordRequest } from '../models/requests/reset-password-request';
 

--- a/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/reset-password/reset-password.component.ts
@@ -33,7 +33,7 @@ export class ResetPasswordComponent implements OnInit {
       },
       error: (error: any) => {
         this.loading = false;
-        this.validationErrors = error.error;
+        this.validationErrors.push(error.error);
       }
     });
   }

--- a/src/Smp.Web/ClientApp/src/app/search/search.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/search/search.component.spec.ts
@@ -1,20 +1,20 @@
-import { TestBed, ComponentFixture } from "@angular/core/testing";
-import { SearchComponent } from "./search.component";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SearchComponent } from './search.component';
 
-describe("SearchComponent", () => {
+describe('SearchComponent', () => {
   let component: SearchComponent;
   let fixture: ComponentFixture<SearchComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [SearchComponent]
+      declarations: [SearchComponent],
     }).compileComponents();
     fixture = TestBed.createComponent(SearchComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it("should create", () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/search/search.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/search/search.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+
 import { SearchComponent } from './search.component';
 
 describe('SearchComponent', () => {
@@ -14,7 +15,7 @@ describe('SearchComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should have been created', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/search/search.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/search/search.component.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { SearchComponent } from "./search.component";
+
+describe("SearchComponent", () => {
+  let component: SearchComponent;
+  let fixture: ComponentFixture<SearchComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SearchComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
 import { AccountsService } from './accounts.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('AccountsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+  }));
 
   it('should be created', () => {
     const service: AccountsService = TestBed.get(AccountsService);

--- a/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
@@ -2,15 +2,60 @@ import { TestBed } from '@angular/core/testing';
 
 import { AccountsService } from './accounts.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
+import { ResetPasswordRequest } from '../models/requests/reset-password-request';
 
 describe('AccountsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
+  const baseUrl = 'https://www.smp.org/';
+
+  let service: AccountsService;
+  let httpClient: HttpClient;
+
+  let httpClientGetSpy: jasmine.Spy;
+  let httpClientPostSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
     imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-  }));
+    providers: [{ provide: 'BASE_URL', useValue: baseUrl }]
+    });
+
+    httpClient = TestBed.get(HttpClient);
+    service = TestBed.get(AccountsService);
+
+    httpClientGetSpy = spyOn(httpClient, 'get');
+    httpClientPostSpy = spyOn(httpClient, 'post');
+  });
+
 
   it('should be created', () => {
-    const service: AccountsService = TestBed.get(AccountsService);
     expect(service).toBeTruthy();
+  });
+
+  describe('forgottenPassword', () => {
+    const email = 'my@email.com';
+
+    it('should have called HttpClient.get correctly', () => {
+      service.forgottenPassword(email);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0))
+        .toEqual([`${baseUrl}api/Accounts/ForgottenPassword/${email}`]);
+    });
+  });
+
+  describe('resetPassword', () => {
+    const resetReq = { 
+      actionId: 'actionId',
+      newPassword: 'newPassword',
+      confirmNewPassword: 'newPassword'
+    } as ResetPasswordRequest;
+
+    it('should have called HttpClient.post correctly', () => {
+      service.resetPassword(resetReq);
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0))
+        .toEqual([`${baseUrl}api/Accounts/ResetPassword`, resetReq]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
@@ -3,22 +3,21 @@ import { TestBed } from '@angular/core/testing';
 import { AccountsService } from './accounts.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpClient } from '@angular/common/http';
-import { of } from 'rxjs';
 import { ResetPasswordRequest } from '../models/requests/reset-password-request';
 
 describe('AccountsService', () => {
   const baseUrl = 'https://www.smp.org/';
 
-  let service: AccountsService;
   let httpClient: HttpClient;
+  let service: AccountsService;
 
   let httpClientGetSpy: jasmine.Spy;
   let httpClientPostSpy: jasmine.Spy;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: baseUrl }]
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: baseUrl }]
     });
 
     httpClient = TestBed.get(HttpClient);
@@ -26,11 +25,6 @@ describe('AccountsService', () => {
 
     httpClientGetSpy = spyOn(httpClient, 'get');
     httpClientPostSpy = spyOn(httpClient, 'post');
-  });
-
-
-  it('should be created', () => {
-    expect(service).toBeTruthy();
   });
 
   describe('forgottenPassword', () => {

--- a/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/accounts.service.spec.ts
@@ -1,55 +1,45 @@
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { AccountsService } from './accounts.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpClient } from '@angular/common/http';
 import { ResetPasswordRequest } from '../models/requests/reset-password-request';
 
 describe('AccountsService', () => {
-  const baseUrl = 'https://www.smp.org/';
-
-  let httpClient: HttpClient;
+  const baseUrl: string = 'https://www.smp.org/';
   let service: AccountsService;
-
-  let httpClientGetSpy: jasmine.Spy;
-  let httpClientPostSpy: jasmine.Spy;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [{ provide: 'BASE_URL', useValue: baseUrl }]
+      providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
     });
-
-    httpClient = TestBed.get(HttpClient);
     service = TestBed.get(AccountsService);
-
-    httpClientGetSpy = spyOn(httpClient, 'get');
-    httpClientPostSpy = spyOn(httpClient, 'post');
   });
 
-  describe('forgottenPassword', () => {
-    const email = 'my@email.com';
+  describe('forgottenPassword()', () => {
+    const email: string = 'my@email.com';
 
-    it('should have called HttpClient.get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
+      spyOn(TestBed.get(HttpClient), 'get');
       service.forgottenPassword(email);
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0))
-        .toEqual([`${baseUrl}api/Accounts/ForgottenPassword/${email}`]);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(`${baseUrl}api/Accounts/ForgottenPassword/${email}`);
     });
   });
 
-  describe('resetPassword', () => {
-    const resetReq = { 
+  describe('resetPassword()', () => {
+    const resetReq: ResetPasswordRequest = {
       actionId: 'actionId',
       newPassword: 'newPassword',
-      confirmNewPassword: 'newPassword'
+      confirmNewPassword: 'newPassword',
     } as ResetPasswordRequest;
 
-    it('should have called HttpClient.post correctly', () => {
+    it('should have called HttpClient.post() correctly', () => {
+      spyOn(TestBed.get(HttpClient), 'post');
       service.resetPassword(resetReq);
-      expect(httpClientPostSpy.calls.count()).toEqual(1);
-      expect(httpClientPostSpy.calls.argsFor(0))
-        .toEqual([`${baseUrl}api/Accounts/ResetPassword`, resetReq]);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledWith(`${baseUrl}api/Accounts/ResetPassword`, resetReq);
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-
 import { of, Observable } from 'rxjs';
+
 import { Conversation } from '../models/conversation';
 import { ConversationsService } from './conversations.service';
 import { CreateConversationRequest } from '../models/requests/create-conversation-request';

--- a/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
@@ -1,145 +1,121 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { ConversationsService } from './conversations.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { of, Observable } from 'rxjs';
 import { Conversation } from '../models/conversation';
-import { of } from 'rxjs';
+import { ConversationsService } from './conversations.service';
 import { CreateConversationRequest } from '../models/requests/create-conversation-request';
 
 describe('ConversationsService', () => {
-  const baseUrl = 'https://www.smp.org/';
-
+  const authHeaders: HttpHeaders = new HttpHeaders().set('Authorization', 'Bearer token');
+  const baseUrl: string = 'https://www.smp.org/';
   let service: ConversationsService;
-
-  let httpClientGetSpy: jasmine.Spy;
-  let httpClientPostSpy: jasmine.Spy;
-
-  const authHeaders = new HttpHeaders().set('Authorization', 'Bearer token');
 
   beforeAll(() => {
     localStorage.setItem('currentUser', '{ "id": "id", "token": "token" }');
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
+    });
+    service = TestBed.get(ConversationsService);
   });
 
   afterAll(() => {
     localStorage.removeItem('currentUser');
   });
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-    });
-
-    service = TestBed.get(ConversationsService);
-  });
-
-  describe('getConversations', () => {
-    beforeEach(async() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get')
-        .and.returnValue(of(expectedConversations));
-    });
-
-    const userId = 'userId';
+  describe('getConversations()', () => {
+    const userId: string = 'userId';
     const expectedConversations: Conversation[] = [
       {
         id: 'conversationId-1',
-        createdAt: new Date()
+        createdAt: new Date(),
       },
       {
         id: 'conversationId-2',
-        createdAt: new Date()
-      }
+        createdAt: new Date(),
+      },
     ];
 
+    beforeEach(() => {
+      spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expectedConversations));
+    });
+
     it('should have returned the expected values', () => {
-      const conversationsObserv = service.getConversations(userId);
-      
+      const conversationsObserv: Observable<Conversation[]> = service.getConversations(userId);
       conversationsObserv.subscribe({
-        next: ((conversations: Conversation[]) => {
+        next: (conversations: Conversation[]) => {
           expect(conversations).toEqual(expectedConversations);
-        })
+        },
       });
     });
 
-    it('should have called HttpClient get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
       service.getConversations(userId);
-
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0))
-        .toEqual([
-          `${baseUrl}api/Conversations/GetConversations/${userId}`,
-          { headers: authHeaders }
-      ]);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
+        `${baseUrl}api/Conversations/GetConversations/${userId}`,
+        { headers: authHeaders }
+      );
     });
   });
 
-  describe('getConversationParticipants', () => {
-    beforeEach(async() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get')
-        .and.returnValue(of(expectedUserIds));
-    });
+  describe('getConversationParticipants()', () => {
+    const conversationId: string = 'conversationId';
+    const expectedUserIds: string[] = ['userOne', 'userTwo', 'userThree'];
 
-    const conversationId = 'conversationId';
-    const expectedUserIds: string[] = [
-      'userOne',
-      'userTwo',
-      'userThree'
-    ];
+    beforeEach(() => {
+      spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expectedUserIds));
+    });
 
     it('should have returned the expected values', () => {
-      const userIdsObserv = service.getConversationParticipants(conversationId);
-      
+      const userIdsObserv: Observable<string[]> = service.getConversationParticipants(conversationId);
       userIdsObserv.subscribe({
-        next: ((ids: string[]) => {
+        next: (ids: string[]) => {
           expect(ids).toEqual(expectedUserIds);
-        })
+        },
       });
     });
 
-    it('should have called HttpClient get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
       service.getConversationParticipants(conversationId);
-
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0))
-        .toEqual([
-          `${baseUrl}api/Conversations/GetConversationParticipants/${conversationId}`,
-          { headers: authHeaders }
-        ]);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
+        `${baseUrl}api/Conversations/GetConversationParticipants/${conversationId}`,
+        { headers: authHeaders }
+      );
     });
   });
 
-  describe('createConversation', () => {
-    beforeEach(async() => {
-      httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post')
-        .and.returnValue(of(expectedConversationId));
-    });
+  describe('createConversation()', () => {
+    const convReq: CreateConversationRequest = { senderId: 'senderId' } as CreateConversationRequest;
+    const expectedConversationId: string = 'conversationId';
 
-    const expectedConversationId = 'conversationId';
-    const convReq = {
-      senderId: 'senderId'
-    } as CreateConversationRequest;
+    beforeEach(async () => {
+      spyOn(TestBed.get(HttpClient), 'post').and.returnValue(of(expectedConversationId));
+    });
 
     it('should have returned the expected value', () => {
-      const convIdObserv = service.createConversation(convReq);
-
+      const convIdObserv: Observable<Object> = service.createConversation(convReq);
       convIdObserv.subscribe({
-        next: ((id: string) => {
+        next: (id: string) => {
           expect(id).toEqual(expectedConversationId);
-        })
+        },
       });
     });
 
-    it('should have called HttpClient post correctly', () => {
+    it('should have called HttpClient.post() correctly', () => {
       service.createConversation(convReq);
-
-      expect(httpClientPostSpy.calls.count()).toEqual(1);
-      expect(httpClientPostSpy.calls.argsFor(0))
-        .toEqual([
-          `${baseUrl}api/Conversations/CreateConversation`,
-          convReq,
-          { headers: authHeaders }
-        ]);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledWith(
+        `${baseUrl}api/Conversations/CreateConversation`,
+        convReq,
+        { headers: authHeaders }
+      );
     });
-  })
+  });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ConversationsService } from './conversations.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ConversationsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+  }));
 
   it('should be created', () => {
     const service: ConversationsService = TestBed.get(ConversationsService);

--- a/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/conversations.service.spec.ts
@@ -2,15 +2,144 @@ import { TestBed } from '@angular/core/testing';
 
 import { ConversationsService } from './conversations.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Conversation } from '../models/conversation';
+import { of } from 'rxjs';
+import { CreateConversationRequest } from '../models/requests/create-conversation-request';
 
 describe('ConversationsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-  }));
+  const baseUrl = 'https://www.smp.org/';
 
-  it('should be created', () => {
-    const service: ConversationsService = TestBed.get(ConversationsService);
-    expect(service).toBeTruthy();
+  let service: ConversationsService;
+
+  let httpClientGetSpy: jasmine.Spy;
+  let httpClientPostSpy: jasmine.Spy;
+
+  const authHeaders = new HttpHeaders().set('Authorization', 'Bearer token');
+
+  beforeAll(() => {
+    localStorage.setItem('currentUser', '{ "id": "id", "token": "token" }');
   });
+
+  afterAll(() => {
+    localStorage.removeItem('currentUser');
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+    });
+
+    service = TestBed.get(ConversationsService);
+  });
+
+  describe('getConversations', () => {
+    beforeEach(async() => {
+      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get')
+        .and.returnValue(of(expectedConversations));
+    });
+
+    const userId = 'userId';
+    const expectedConversations: Conversation[] = [
+      {
+        id: 'conversationId-1',
+        createdAt: new Date()
+      },
+      {
+        id: 'conversationId-2',
+        createdAt: new Date()
+      }
+    ];
+
+    it('should have returned the expected values', () => {
+      const conversationsObserv = service.getConversations(userId);
+      
+      conversationsObserv.subscribe({
+        next: ((conversations: Conversation[]) => {
+          expect(conversations).toEqual(expectedConversations);
+        })
+      });
+    });
+
+    it('should have called HttpClient get correctly', () => {
+      service.getConversations(userId);
+
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0))
+        .toEqual([
+          `${baseUrl}api/Conversations/GetConversations/${userId}`,
+          { headers: authHeaders }
+      ]);
+    });
+  });
+
+  describe('getConversationParticipants', () => {
+    beforeEach(async() => {
+      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get')
+        .and.returnValue(of(expectedUserIds));
+    });
+
+    const conversationId = 'conversationId';
+    const expectedUserIds: string[] = [
+      'userOne',
+      'userTwo',
+      'userThree'
+    ];
+
+    it('should have returned the expected values', () => {
+      const userIdsObserv = service.getConversationParticipants(conversationId);
+      
+      userIdsObserv.subscribe({
+        next: ((ids: string[]) => {
+          expect(ids).toEqual(expectedUserIds);
+        })
+      });
+    });
+
+    it('should have called HttpClient get correctly', () => {
+      service.getConversationParticipants(conversationId);
+
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0))
+        .toEqual([
+          `${baseUrl}api/Conversations/GetConversationParticipants/${conversationId}`,
+          { headers: authHeaders }
+        ]);
+    });
+  });
+
+  describe('createConversation', () => {
+    beforeEach(async() => {
+      httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post')
+        .and.returnValue(of(expectedConversationId));
+    });
+
+    const expectedConversationId = 'conversationId';
+    const convReq = {
+      senderId: 'senderId'
+    } as CreateConversationRequest;
+
+    it('should have returned the expected value', () => {
+      const convIdObserv = service.createConversation(convReq);
+
+      convIdObserv.subscribe({
+        next: ((id: string) => {
+          expect(id).toEqual(expectedConversationId);
+        })
+      });
+    });
+
+    it('should have called HttpClient post correctly', () => {
+      service.createConversation(convReq);
+
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0))
+        .toEqual([
+          `${baseUrl}api/Conversations/CreateConversation`,
+          convReq,
+          { headers: authHeaders }
+        ]);
+    });
+  })
 });

--- a/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
@@ -2,15 +2,100 @@ import { TestBed } from '@angular/core/testing';
 
 import { MessagesService } from './messages.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { CreateMessageRequest } from '../models/requests/create-message-request';
+import { of } from 'rxjs';
+import { Message, FriendlyMessage } from '../models/message';
 
 describe('MessagesService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-  }));
+  const baseUrl = 'https://www.smp.org/';
 
-  it('should be created', () => {
-    const service: MessagesService = TestBed.get(MessagesService);
-    expect(service).toBeTruthy();
+  let httpClient: HttpClient;
+  let service: MessagesService;
+
+  let httpClientGetSpy: jasmine.Spy;
+  let httpClientPostSpy: jasmine.Spy;
+
+  const authHeaders = new HttpHeaders().set('Authorization', 'Bearer token');
+
+  beforeAll(() => {
+    localStorage.setItem('currentUser', '{ "id": "id", "token": "token" }');
+  });
+
+  afterAll(() => {
+    localStorage.removeItem('currentUser');
+  })
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+    });
+
+    service = TestBed.get(MessagesService);
+
+    httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post');
+});
+
+  describe('getMessagesFromConversation', () => {
+    beforeEach(() => {
+      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get')
+        .and.returnValue(of(expectedMessages));
+    });
+
+    const conversationId = 'conversationId';
+    const expectedMessages: Message[] = [
+      new Message({
+        id: 1,
+        senderId: 'senderId-1',
+        createdAt: new Date(),
+        content: 'content-1',
+        conversationId: conversationId
+      } as Message),
+      new Message({
+        id: 2,
+        senderId: 'senderId-2',
+        createdAt: new Date(),
+        content: 'content-2',
+        conversationId: conversationId
+      } as Message)
+    ];
+
+    it('shouild have returned the expected value', () => {
+      const messagesObserv = service.getMessagesFromConversation(conversationId);
+
+      messagesObserv.subscribe({
+        next: (messages: FriendlyMessage[]) => {
+          expect(messages).toEqual(expectedMessages.map(msg => new FriendlyMessage(msg)));
+        }
+      });
+    });
+
+    it('should have called HttpClient get correctly', () => {
+      service.getMessagesFromConversation(conversationId);
+
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Messages/GetMessagesFromConversation/${conversationId}?count=10&page=0`,
+        { headers: authHeaders }
+      ]);
+    });
+  });
+
+  describe('createMessage', () => {
+    const msgReq = {
+      senderId: 'senderId'
+    } as CreateMessageRequest;
+
+    it('should have called HttpClient post correctly', () => {
+      service.createMessage(msgReq);
+
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Messages/CreateMessage`,
+        msgReq,
+        { headers: authHeaders }
+      ]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-
 import { of, Observable } from 'rxjs';
+
 import { CreateMessageRequest } from '../models/requests/create-message-request';
 import { FriendlyMessage, Message } from '../models/message';
 import { MessagesService } from './messages.service';
@@ -30,23 +30,23 @@ describe('MessagesService', () => {
   });
 
   describe('getMessagesFromConversation()', () => {
-    const conversationId = 'conversationId';
+    const conversationId: string = 'conversationId';
     const expectedMessages: Message[] = [
-      new Message({
+      {
         id: 1,
         senderId: 'senderId-1',
         createdAt: new Date(),
         content: 'content-1',
         conversationId,
-      } as Message),
-      new Message({
+      },
+      {
         id: 2,
         senderId: 'senderId-2',
         createdAt: new Date(),
         content: 'content-2',
         conversationId,
-      } as Message),
-    ];
+      },
+    ] as Message[];
 
     beforeEach(() => {
       spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expectedMessages));
@@ -67,7 +67,7 @@ describe('MessagesService', () => {
       expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
       expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
         `${baseUrl}api/Messages/GetMessagesFromConversation/${conversationId}?count=10&page=0`,
-        { headers: authHeaders },
+        { headers: authHeaders }
       );
     });
   });

--- a/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
 import { MessagesService } from './messages.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('MessagesService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+  }));
 
   it('should be created', () => {
     const service: MessagesService = TestBed.get(MessagesService);

--- a/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/messages.service.spec.ts
@@ -24,7 +24,7 @@ describe('MessagesService', () => {
 
   afterAll(() => {
     localStorage.removeItem('currentUser');
-  })
+  });
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/src/Smp.Web/ClientApp/src/app/services/posts.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/posts.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-
 import { of, Observable } from 'rxjs';
+
 import { CreatePostRequest } from '../models/requests/create-post-request';
 import { Post } from '../models/post';
 import { PostsService } from './posts.service';

--- a/src/Smp.Web/ClientApp/src/app/services/posts.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/posts.service.spec.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
 import { PostsService } from './posts.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('PostsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+  }));
 
   it('should be created', () => {
     const service: PostsService = TestBed.get(PostsService);

--- a/src/Smp.Web/ClientApp/src/app/services/posts.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/posts.service.spec.ts
@@ -2,15 +2,87 @@ import { TestBed } from '@angular/core/testing';
 
 import { PostsService } from './posts.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpHeaders, HttpClient } from '@angular/common/http';
+import { CreatePostRequest } from '../models/requests/create-post-request';
+import { of } from 'rxjs';
+import { Post } from '../models/post';
 
 describe('PostsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-  }));
+  const baseUrl = 'https://www.smp.org/';
 
-  it('should be created', () => {
-    const service: PostsService = TestBed.get(PostsService);
-    expect(service).toBeTruthy();
+  let service: PostsService;
+
+  let httpClientGetSpy: jasmine.Spy;
+  let httpClientPostSpy: jasmine.Spy;
+
+  const authHeaders = new HttpHeaders().set('Authorization', 'Bearer token');
+
+  beforeAll(() => {
+    localStorage.setItem('currentUser', '{ "id": "id", "token": "token" }');
+  });
+
+  afterAll(() => {
+    localStorage.removeItem('currentUser');
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+    });
+
+    httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post');
+
+    service = TestBed.get(PostsService);
+  });
+
+  describe('createPost', () => {
+    const postReq = {
+      senderId: 'senderId'
+    } as CreatePostRequest;
+
+    it('should have called HttpClient post correctly', () => {
+      service.createPost(postReq);
+
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Posts/CreatePost`,
+        postReq,
+        { headers: authHeaders }
+      ]);
+    });
+  });
+
+  describe('getPosts', () => {
+    beforeEach(() => {
+      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get')
+        .and.returnValue(of(expectedPosts));
+    });
+
+    const receiverId = 'receiverId';
+    const expectedPosts: Post[] = [
+      { content: 'content-1' } as Post,
+      { content: 'content-2' } as Post
+    ]
+
+    it('should have returned the expected value', () => {
+      const postsObserv = service.getPosts(receiverId);
+
+      postsObserv.subscribe({
+        next: ((posts: Post[]) => {
+          expect(posts).toEqual(expectedPosts);
+        })
+      });
+    });
+
+    it('should have called HttpClient get correctly', () => {
+      service.getPosts(receiverId);
+
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Posts/GetPosts/${receiverId}`,
+        { headers: authHeaders }
+      ]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
@@ -59,7 +59,7 @@ describe('RelationshipsService', () => {
       ]);
     });
 
-    it('should have returned the expected values', () => {
+    it('should have returned the expected value', () => {
       const result = service.getRelationship(userOneId, userTwoId, relationshipType);
       result.subscribe({
         next: (relationship: Relationship) => {

--- a/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
@@ -2,6 +2,8 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
+import { of } from 'rxjs';
+import { Relationship } from '../models/relationship';
 import { RelationshipType } from '../models/relationship-type.enum';
 import { RelationshipsService } from './relationships.service';
 
@@ -11,7 +13,6 @@ describe('RelationshipsService', () => {
   const userTwoId = 'adsifasfuh1231231-asxzcz9v8bc9-213123';
   const relationshipType = RelationshipType.Friend;
   let headers: Object;
-  let httpClient: HttpClient;
   let httpClientGetSpy: jasmine.Spy;
   let service: RelationshipsService;
 
@@ -31,8 +32,6 @@ describe('RelationshipsService', () => {
       providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
     });
     service = TestBed.get(RelationshipsService);
-    httpClient = TestBed.get(HttpClient);
-    httpClientGetSpy = spyOn(httpClient, 'get');
   });
 
   afterAll(() => {
@@ -40,6 +39,17 @@ describe('RelationshipsService', () => {
   });
 
   describe('getRelationship', () => {
+    const expected: Relationship = {
+      userOneId,
+      userTwoId,
+      relationshipType,
+      createdAt: new Date(),
+    } as Relationship;
+
+    beforeEach(() => {
+      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expected));
+    });
+
     it('should have called HttpClient.get correctly', () => {
       service.getRelationship(userOneId, userTwoId, relationshipType);
       expect(httpClientGetSpy.calls.count()).toEqual(1);
@@ -48,9 +58,37 @@ describe('RelationshipsService', () => {
         headers,
       ]);
     });
+
+    it('should have returned the expected values', () => {
+      const result = service.getRelationship(userOneId, userTwoId, relationshipType);
+      result.subscribe({
+        next: (relationship: Relationship) => {
+          expect(relationship).toEqual(expected);
+        },
+      });
+    });
   });
 
   describe('getRelationships', () => {
+    const expected: Relationship[] = [
+      {
+        userOneId,
+        userTwoId,
+        relationshipType,
+        createdAt: new Date(),
+      },
+      {
+        userOneId,
+        userTwoId,
+        relationshipType,
+        createdAt: new Date(),
+      },
+    ] as Relationship[];
+
+    beforeEach(() => {
+      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of());
+    });
+
     it('should have called HttpClient.get correctly', () => {
       service.getRelationships(userOneId, relationshipType);
       expect(httpClientGetSpy.calls.count()).toEqual(1);
@@ -58,6 +96,15 @@ describe('RelationshipsService', () => {
         `${baseUrl}api/Relationships/GetRelationships/${userOneId}/${relationshipType}`,
         headers,
       ]);
+    });
+
+    it('should have returned the expected values', () => {
+      const result = service.getRelationships(userOneId, relationshipType);
+      result.subscribe({
+        next: (relationships: Relationship[]) => {
+          expect(relationships).toEqual(expected);
+        },
+      });
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
@@ -9,9 +9,12 @@ import { RelationshipsService } from './relationships.service';
 
 describe('RelationshipsService', () => {
   const baseUrl = 'https://www.smp.org/';
-  const userOneId = 'aksdfnknkj-123sdf-0asdfasd';
-  const userTwoId = 'adsifasfuh1231231-asxzcz9v8bc9-213123';
-  const relationshipType = RelationshipType.Friend;
+  const relationship: Relationship = {
+    userOneId: 'aksdfnknkj-123sdf-0asdfasd',
+    userTwoId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
+    relationshipType: RelationshipType.Friend,
+    createdAt: new Date(),
+  } as Relationship;
   let headers: Object;
   let httpClientGetSpy: jasmine.Spy;
   let service: RelationshipsService;
@@ -39,67 +42,59 @@ describe('RelationshipsService', () => {
   });
 
   describe('getRelationship', () => {
-    const expected: Relationship = {
-      userOneId,
-      userTwoId,
-      relationshipType,
-      createdAt: new Date(),
-    } as Relationship;
-
     beforeEach(() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expected));
+      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(relationship));
     });
 
     it('should have called HttpClient.get correctly', () => {
-      service.getRelationship(userOneId, userTwoId, relationshipType);
+      service.getRelationship(
+        relationship.userOneId,
+        relationship.userTwoId,
+        relationship.relationshipType
+      );
       expect(httpClientGetSpy.calls.count()).toEqual(1);
       expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
-        `${baseUrl}api/Relationships/GetRelationship/${userOneId}/${userTwoId}/${relationshipType}`,
+        `${baseUrl}api/Relationships/GetRelationship/${relationship.userOneId}/` +
+          `${relationship.userTwoId}/${relationship.relationshipType}`,
         headers,
       ]);
     });
 
     it('should have returned the expected value', () => {
-      const result = service.getRelationship(userOneId, userTwoId, relationshipType);
+      const result = service.getRelationship(
+        relationship.userOneId,
+        relationship.userTwoId,
+        relationship.relationshipType
+      );
       result.subscribe({
         next: (relationship: Relationship) => {
-          expect(relationship).toEqual(expected);
+          expect(relationship).toEqual(relationship);
         },
       });
     });
   });
 
   describe('getRelationships', () => {
-    const expected: Relationship[] = [
-      {
-        userOneId,
-        userTwoId,
-        relationshipType,
-        createdAt: new Date(),
-      },
-      {
-        userOneId,
-        userTwoId,
-        relationshipType,
-        createdAt: new Date(),
-      },
-    ] as Relationship[];
+    const expected: Relationship[] = [relationship, relationship] as Relationship[];
 
     beforeEach(() => {
       httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of());
     });
 
     it('should have called HttpClient.get correctly', () => {
-      service.getRelationships(userOneId, relationshipType);
+      service.getRelationships(relationship.userOneId, relationship.relationshipType);
       expect(httpClientGetSpy.calls.count()).toEqual(1);
       expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
-        `${baseUrl}api/Relationships/GetRelationships/${userOneId}/${relationshipType}`,
+        `${baseUrl}api/Relationships/GetRelationships/${relationship.userOneId}/${relationship.relationshipType}`,
         headers,
       ]);
     });
 
     it('should have returned the expected values', () => {
-      const result = service.getRelationships(userOneId, relationshipType);
+      const result = service.getRelationships(
+        relationship.userOneId,
+        relationship.relationshipType
+      );
       result.subscribe({
         next: (relationships: Relationship[]) => {
           expect(relationships).toEqual(expected);

--- a/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
 import { RelationshipsService } from './relationships.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('RelationshipsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+  }));
 
   it('should be created', () => {
     const service: RelationshipsService = TestBed.get(RelationshipsService);

--- a/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
@@ -1,16 +1,63 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
+import { RelationshipType } from '../models/relationship-type.enum';
 import { RelationshipsService } from './relationships.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('RelationshipsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-  }));
+  const baseUrl = 'https://www.smp.org/';
+  const userOneId = 'aksdfnknkj-123sdf-0asdfasd';
+  const userTwoId = 'adsifasfuh1231231-asxzcz9v8bc9-213123';
+  const relationshipType = RelationshipType.Friend;
+  let headers: Object;
+  let httpClient: HttpClient;
+  let httpClientGetSpy: jasmine.Spy;
+  let service: RelationshipsService;
 
-  it('should be created', () => {
-    const service: RelationshipsService = TestBed.get(RelationshipsService);
-    expect(service).toBeTruthy();
+  beforeAll(() => {
+    localStorage.setItem('currentUser', JSON.stringify({ token: 'n21k32n3j' }));
+    headers = {
+      headers: new HttpHeaders().set(
+        'Authorization',
+        `Bearer ${JSON.parse(localStorage.getItem('currentUser')).token}`
+      ),
+    };
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
+    });
+    service = TestBed.get(RelationshipsService);
+    httpClient = TestBed.get(HttpClient);
+    httpClientGetSpy = spyOn(httpClient, 'get');
+  });
+
+  afterAll(() => {
+    localStorage.removeItem('currentUser');
+  });
+
+  describe('getRelationship', () => {
+    it('should have called HttpClient.get correctly', () => {
+      service.getRelationship(userOneId, userTwoId, relationshipType);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Relationships/GetRelationship/${userOneId}/${userTwoId}/${relationshipType}`,
+        headers,
+      ]);
+    });
+  });
+
+  describe('getRelationships', () => {
+    it('should have called HttpClient.get correctly', () => {
+      service.getRelationships(userOneId, relationshipType);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Relationships/GetRelationships/${userOneId}/${relationshipType}`,
+        headers,
+      ]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-
 import { of, Observable } from 'rxjs';
+
 import { Relationship } from '../models/relationship';
 import { RelationshipType } from '../models/relationship-type.enum';
 import { RelationshipsService } from './relationships.service';

--- a/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/relationships.service.spec.ts
@@ -2,13 +2,13 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { of } from 'rxjs';
+import { of, Observable } from 'rxjs';
 import { Relationship } from '../models/relationship';
 import { RelationshipType } from '../models/relationship-type.enum';
 import { RelationshipsService } from './relationships.service';
 
 describe('RelationshipsService', () => {
-  const baseUrl = 'https://www.smp.org/';
+  const baseUrl: string = 'https://www.smp.org/';
   const relationship: Relationship = {
     userOneId: 'aksdfnknkj-123sdf-0asdfasd',
     userTwoId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
@@ -16,7 +16,6 @@ describe('RelationshipsService', () => {
     createdAt: new Date(),
   } as Relationship;
   let headers: Object;
-  let httpClientGetSpy: jasmine.Spy;
   let service: RelationshipsService;
 
   beforeAll(() => {
@@ -41,57 +40,53 @@ describe('RelationshipsService', () => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('getRelationship', () => {
+  describe('getRelationship()', () => {
     beforeEach(() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(relationship));
+      spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(relationship));
     });
 
-    it('should have called HttpClient.get correctly', () => {
-      service.getRelationship(
-        relationship.userOneId,
-        relationship.userTwoId,
-        relationship.relationshipType
-      );
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+    it('should have called HttpClient.get() correctly', () => {
+      service.getRelationship(relationship.userOneId, relationship.userTwoId, relationship.relationshipType);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
         `${baseUrl}api/Relationships/GetRelationship/${relationship.userOneId}/` +
           `${relationship.userTwoId}/${relationship.relationshipType}`,
-        headers,
-      ]);
+        headers
+      );
     });
 
     it('should have returned the expected value', () => {
-      const result = service.getRelationship(
+      const result: Observable<Relationship> = service.getRelationship(
         relationship.userOneId,
         relationship.userTwoId,
         relationship.relationshipType
       );
       result.subscribe({
-        next: (relationship: Relationship) => {
-          expect(relationship).toEqual(relationship);
+        next: (ship: Relationship) => {
+          expect(ship).toEqual(relationship);
         },
       });
     });
   });
 
-  describe('getRelationships', () => {
+  describe('getRelationships()', () => {
     const expected: Relationship[] = [relationship, relationship] as Relationship[];
 
     beforeEach(() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of());
+      spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of());
     });
 
-    it('should have called HttpClient.get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
       service.getRelationships(relationship.userOneId, relationship.relationshipType);
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
         `${baseUrl}api/Relationships/GetRelationships/${relationship.userOneId}/${relationship.relationshipType}`,
-        headers,
-      ]);
+        headers
+      );
     });
 
     it('should have returned the expected values', () => {
-      const result = service.getRelationships(
+      const result: Observable<Relationship[]> = service.getRelationships(
         relationship.userOneId,
         relationship.relationshipType
       );

--- a/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
@@ -2,17 +2,15 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { of } from 'rxjs';
+import { of, Observable } from 'rxjs';
 import { CreateRequestRequest } from '../models/requests/create-request-request';
 import { Request } from '../models/request';
 import { RequestType } from '../models/request-type.enum';
 import { RequestsService } from './requests.service';
 
 describe('RequestsService', () => {
-  const baseUrl = 'https://www.smp.org/';
+  const baseUrl: string = 'https://www.smp.org/';
   let headers: Object;
-  let httpClientGetSpy: jasmine.Spy;
-  let httpClientPostSpy: jasmine.Spy;
   let service: RequestsService;
 
   beforeAll(() => {
@@ -31,32 +29,28 @@ describe('RequestsService', () => {
       providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
     });
     service = TestBed.get(RequestsService);
-    httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post');
+    spyOn(TestBed.get(HttpClient), 'post');
   });
 
   afterAll(() => {
     localStorage.removeItem('currentUser');
   });
 
-  describe('sendRequest', () => {
+  describe('sendRequest()', () => {
     const req: CreateRequestRequest = new CreateRequestRequest(
       'aksdfnknkj-123sdf-0asdfasd',
       'adsifasfuh1231231-asxzcz9v8bc9-213123',
       RequestType.Friend
     );
 
-    it('should have called HttpClient.post correctly', () => {
+    it('should have called HttpClient.post() correctly', () => {
       service.sendRequest(req);
-      expect(httpClientPostSpy.calls.count()).toEqual(1);
-      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([
-        `${baseUrl}api/Requests/SendRequest/`,
-        req,
-        headers,
-      ]);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledWith(`${baseUrl}api/Requests/SendRequest/`, req, headers);
     });
   });
 
-  describe('getRequest', () => {
+  describe('getRequest()', () => {
     const req = {
       senderId: 'aksdfnknkj-123sdf-0asdfasd',
       receiverId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
@@ -68,20 +62,20 @@ describe('RequestsService', () => {
     } as Request;
 
     beforeEach(() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expected));
+      spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expected));
     });
 
-    it('should have called HttpClient.get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
       service.getRequest(req.senderId, req.receiverId, req.requestType);
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
         `${baseUrl}api/Requests/GetRequest/${req.senderId}/${req.requestType}/${req.receiverId}`,
-        headers,
-      ]);
+        headers
+      );
     });
 
     it('should have returned the expected value', () => {
-      const result = service.getRequest(req.senderId, req.receiverId, req.requestType);
+      const result: Observable<Request> = service.getRequest(req.senderId, req.receiverId, req.requestType);
       result.subscribe({
         next: (request: Request) => {
           expect(request).toEqual(expected);
@@ -90,7 +84,7 @@ describe('RequestsService', () => {
     });
   });
 
-  describe('getIncomingRequests', () => {
+  describe('getIncomingRequests()', () => {
     const userId: string = 'aksdfnknkj-123sdf-0asdfasd';
     const expected: Request[] = [
       {
@@ -108,20 +102,20 @@ describe('RequestsService', () => {
     ] as Request[];
 
     beforeEach(() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expected));
+      spyOn(TestBed.get(HttpClient), 'get').and.returnValue(of(expected));
     });
 
-    it('should have called HttpClient.get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
       service.getIncomingRequests(userId);
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
         `${baseUrl}api/Requests/GetIncomingRequests/${userId}`,
-        headers,
-      ]);
+        headers
+      );
     });
 
     it('should have returned the expected values', () => {
-      const result = service.getIncomingRequests(userId);
+      const result: Observable<Request[]> = service.getIncomingRequests(userId);
       result.subscribe({
         next: (request: Request[]) => {
           expect(request).toEqual(expected);
@@ -132,10 +126,10 @@ describe('RequestsService', () => {
 
   describe('acceptRequest', () => {
     beforeEach(() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get');
+      spyOn(TestBed.get(HttpClient), 'get');
     });
 
-    it('should have called HttpClient.get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
       const req: Request = {
         receiverId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
         senderId: 'aksdfnknkj-123sdf-0asdfasd',
@@ -143,20 +137,20 @@ describe('RequestsService', () => {
         requestType: RequestType.Friend,
       } as Request;
       service.acceptRequest(req);
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
         `${baseUrl}api/Requests/AcceptRequest/${req.receiverId}/${req.requestType}/${req.senderId}`,
-        headers,
-      ]);
+        headers
+      );
     });
   });
 
-  describe('declineRequest', () => {
+  describe('declineRequest()', () => {
     beforeEach(() => {
-      httpClientGetSpy = spyOn(TestBed.get(HttpClient), 'get');
+      spyOn(TestBed.get(HttpClient), 'get');
     });
 
-    it('should have called HttpClient.get correctly', () => {
+    it('should have called HttpClient.get() correctly', () => {
       const req: Request = {
         receiverId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
         senderId: 'aksdfnknkj-123sdf-0asdfasd',
@@ -164,11 +158,11 @@ describe('RequestsService', () => {
         requestType: RequestType.Friend,
       } as Request;
       service.declineRequest(req);
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(
         `${baseUrl}api/Requests/DeclineRequest/${req.receiverId}/${req.requestType}/${req.senderId}`,
-        headers,
-      ]);
+        headers
+      );
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-
 import { of, Observable } from 'rxjs';
+
 import { CreateRequestRequest } from '../models/requests/create-request-request';
 import { Request } from '../models/request';
 import { RequestType } from '../models/request-type.enum';

--- a/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
 import { RequestsService } from './requests.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('RequestsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+  }));
 
   it('should be created', () => {
     const service: RequestsService = TestBed.get(RequestsService);

--- a/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/requests.service.spec.ts
@@ -1,16 +1,122 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
+import { CreateRequestRequest } from '../models/requests/create-request-request';
+import { Request } from '../models/request';
+import { RequestType } from '../models/request-type.enum';
 import { RequestsService } from './requests.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('RequestsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-  }));
+  const baseUrl = 'https://www.smp.org/';
+  let headers: Object;
+  let httpClient: HttpClient;
+  let httpClientGetSpy: jasmine.Spy;
+  let httpClientPostSpy: jasmine.Spy;
+  let service: RequestsService;
 
-  it('should be created', () => {
-    const service: RequestsService = TestBed.get(RequestsService);
-    expect(service).toBeTruthy();
+  beforeAll(() => {
+    localStorage.setItem('currentUser', JSON.stringify({ token: 'n21k32n3j' }));
+    headers = {
+      headers: new HttpHeaders().set(
+        'Authorization',
+        `Bearer ${JSON.parse(localStorage.getItem('currentUser')).token}`
+      ),
+    };
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
+    });
+    service = TestBed.get(RequestsService);
+    httpClient = TestBed.get(HttpClient);
+    httpClientGetSpy = spyOn(httpClient, 'get');
+    httpClientPostSpy = spyOn(httpClient, 'post');
+  });
+
+  afterAll(() => {
+    localStorage.removeItem('currentUser');
+  });
+
+  describe('sendRequest', () => {
+    const req: CreateRequestRequest = new CreateRequestRequest(
+      'aksdfnknkj-123sdf-0asdfasd',
+      'adsifasfuh1231231-asxzcz9v8bc9-213123',
+      RequestType.Friend
+    );
+
+    it('should have called HttpClient.post correctly', () => {
+      service.sendRequest(req);
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Requests/SendRequest/`,
+        req,
+        headers,
+      ]);
+    });
+  });
+
+  describe('getRequest', () => {
+    it('should have called HttpClient.get correctly', () => {
+      const req = {
+        senderId: 'aksdfnknkj-123sdf-0asdfasd',
+        receiverId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
+        reqType: RequestType.Friend,
+      };
+      service.getRequest(req.senderId, req.receiverId, req.reqType);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Requests/GetRequest/${req.senderId}/${req.reqType}/${req.receiverId}`,
+        headers,
+      ]);
+    });
+  });
+
+  describe('getIncomingRequests', () => {
+    it('should have called HttpClient.get correctly', () => {
+      const userId: string = 'aksdfnknkj-123sdf-0asdfasd';
+      service.getIncomingRequests(userId);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Requests/GetIncomingRequests/${userId}`,
+        headers,
+      ]);
+    });
+  });
+
+  describe('acceptRequest', () => {
+    it('should have called HttpClient.get correctly', () => {
+      const req: Request = {
+        receiverId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
+        senderId: 'aksdfnknkj-123sdf-0asdfasd',
+        createdAt: new Date(),
+        requestType: RequestType.Friend,
+      } as Request;
+      service.acceptRequest(req);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Requests/AcceptRequest/${req.receiverId}/${req.requestType}/${req.senderId}`,
+        headers,
+      ]);
+    });
+  });
+
+  describe('declineRequest', () => {
+    it('should have called HttpClient.get correctly', () => {
+      const req: Request = {
+        receiverId: 'adsifasfuh1231231-asxzcz9v8bc9-213123',
+        senderId: 'aksdfnknkj-123sdf-0asdfasd',
+        createdAt: new Date(),
+        requestType: RequestType.Friend,
+      } as Request;
+      service.declineRequest(req);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Requests/DeclineRequest/${req.receiverId}/${req.requestType}/${req.senderId}`,
+        headers,
+      ]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/users.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/users.service.spec.ts
@@ -1,16 +1,66 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
+import { CreateUserRequest } from '../models/requests/create-user-request';
 import { UsersService } from './users.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('UsersService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
-  }));
+  const baseUrl = 'https://www.smp.org/';
+  let httpClient: HttpClient;
+  let httpClientGetSpy: jasmine.Spy;
+  let httpClientPostSpy: jasmine.Spy;
+  let service: UsersService;
 
-  it('should be created', () => {
-    const service: UsersService = TestBed.get(UsersService);
-    expect(service).toBeTruthy();
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
+    });
+    httpClient = TestBed.get(HttpClient);
+    service = TestBed.get(UsersService);
+    httpClientGetSpy = spyOn(httpClient, 'get');
+    httpClientPostSpy = spyOn(httpClient, 'post');
+  });
+
+  describe('createUser', () => {
+    const createUserReq = {
+      fullName: 'John Doe',
+      password: 'lk1jn43kl1nj34###XXCC',
+      confirmPassword: 'lk1jn43kl1nj34###XXCC',
+      email: 'my@email.com',
+    } as CreateUserRequest;
+
+    it('should have called HttpClient.post correctly', () => {
+      service.createUser(createUserReq);
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Users/CreateUser/`,
+        createUserReq,
+      ]);
+    });
+  });
+
+  describe('getUser', () => {
+    const userId = 'aksdjn-123kwqjen-cxnzkj';
+    beforeAll(() => {
+      localStorage.setItem('currentUser', JSON.stringify({ token: 'n21k32n3j' }));
+    });
+    afterAll(() => {
+      localStorage.removeItem('currentUser');
+    });
+
+    it('should have called HttpClient.get correctly', () => {
+      const headers = new HttpHeaders().set(
+        'Authorization',
+        `Bearer ${JSON.parse(localStorage.getItem('currentUser')).token}`
+      );
+      service.getUser(userId);
+      expect(httpClientGetSpy.calls.count()).toEqual(1);
+      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
+        `${baseUrl}api/Users/GetUser/${userId}`,
+        { headers },
+      ]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/users.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/users.service.spec.ts
@@ -6,10 +6,7 @@ import { CreateUserRequest } from '../models/requests/create-user-request';
 import { UsersService } from './users.service';
 
 describe('UsersService', () => {
-  const baseUrl = 'https://www.smp.org/';
-  let httpClient: HttpClient;
-  let httpClientGetSpy: jasmine.Spy;
-  let httpClientPostSpy: jasmine.Spy;
+  const baseUrl: string = 'https://www.smp.org/';
   let service: UsersService;
 
   beforeEach(() => {
@@ -17,50 +14,45 @@ describe('UsersService', () => {
       imports: [HttpClientTestingModule],
       providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
     });
-    httpClient = TestBed.get(HttpClient);
     service = TestBed.get(UsersService);
-    httpClientGetSpy = spyOn(httpClient, 'get');
-    httpClientPostSpy = spyOn(httpClient, 'post');
+    spyOn(TestBed.get(HttpClient), 'get');
+    spyOn(TestBed.get(HttpClient), 'post');
   });
 
-  describe('createUser', () => {
-    const createUserReq = {
+  describe('createUser()', () => {
+    const createUserReq: CreateUserRequest = {
       fullName: 'John Doe',
       password: 'lk1jn43kl1nj34###XXCC',
       confirmPassword: 'lk1jn43kl1nj34###XXCC',
       email: 'my@email.com',
     } as CreateUserRequest;
 
-    it('should have called HttpClient.post correctly', () => {
+    it('should have called HttpClient.post() correctly', () => {
       service.createUser(createUserReq);
-      expect(httpClientPostSpy.calls.count()).toEqual(1);
-      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([
-        `${baseUrl}api/Users/CreateUser/`,
-        createUserReq,
-      ]);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledWith(`${baseUrl}api/Users/CreateUser/`, createUserReq);
     });
   });
 
-  describe('getUser', () => {
-    const userId = 'aksdjn-123kwqjen-cxnzkj';
+  describe('getUser()', () => {
+    const userId: string = 'aksdjn-123kwqjen-cxnzkj';
+
     beforeAll(() => {
       localStorage.setItem('currentUser', JSON.stringify({ token: 'n21k32n3j' }));
     });
+
     afterAll(() => {
       localStorage.removeItem('currentUser');
     });
 
-    it('should have called HttpClient.get correctly', () => {
-      const headers = new HttpHeaders().set(
+    it('should have called HttpClient.get() correctly', () => {
+      const headers: HttpHeaders = new HttpHeaders().set(
         'Authorization',
         `Bearer ${JSON.parse(localStorage.getItem('currentUser')).token}`
       );
       service.getUser(userId);
-      expect(httpClientGetSpy.calls.count()).toEqual(1);
-      expect(httpClientGetSpy.calls.argsFor(0)).toEqual([
-        `${baseUrl}api/Users/GetUser/${userId}`,
-        { headers },
-      ]);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).get).toHaveBeenCalledWith(`${baseUrl}api/Users/GetUser/${userId}`, { headers });
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/services/users.service.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/services/users.service.spec.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
 import { UsersService } from './users.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('UsersService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [{ provide: 'BASE_URL', useValue: "https://www.smp.org/" }]
+  }));
 
   it('should be created', () => {
     const service: UsersService = TestBed.get(UsersService);

--- a/src/Smp.Web/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/settings/settings.component.spec.ts
@@ -1,22 +1,31 @@
-import { TestBed, ComponentFixture } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
-import { SettingsComponent } from "./settings.component";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
-describe("SettingsComponent", () => {
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
   let component: SettingsComponent;
   let fixture: ComponentFixture<SettingsComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [SettingsComponent],
-      imports: [RouterTestingModule]
+      imports: [RouterTestingModule],
     }).compileComponents();
     fixture = TestBed.createComponent(SettingsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe('signOut', () => {
+    it('should navigate to /sign-in', () => {
+      const routerNavigateSpy: jasmine.Spy = spyOn(TestBed.get(Router), 'navigate');
+      localStorage.setItem('currentUser', JSON.stringify({ currentUser: 'bob' }));
+      component.signOut();
+      expect(localStorage.getItem('currentUser')).toBeNull();
+      expect(routerNavigateSpy.calls.count()).toEqual(1);
+      expect(routerNavigateSpy.calls.argsFor(0)).toEqual([['/sign-in']]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/settings/settings.component.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { SettingsComponent } from "./settings.component";
+
+describe("SettingsComponent", () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SettingsComponent],
+      imports: [RouterTestingModule]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Smp.Web/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/settings/settings.component.spec.ts
@@ -18,14 +18,14 @@ describe('SettingsComponent', () => {
     fixture.detectChanges();
   });
 
-  describe('signOut', () => {
-    it('should navigate to /sign-in', () => {
-      const routerNavigateSpy: jasmine.Spy = spyOn(TestBed.get(Router), 'navigate');
+  describe('signOut()', () => {
+    it('should have navigated to /sign-in', () => {
       localStorage.setItem('currentUser', JSON.stringify({ currentUser: 'bob' }));
+      spyOn(TestBed.get(Router), 'navigate');
       component.signOut();
       expect(localStorage.getItem('currentUser')).toBeNull();
-      expect(routerNavigateSpy.calls.count()).toEqual(1);
-      expect(routerNavigateSpy.calls.argsFor(0)).toEqual([['/sign-in']]);
+      expect(TestBed.get(Router).navigate).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(Router).navigate).toHaveBeenCalledWith(['/sign-in']);
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
@@ -1,0 +1,25 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { RouterTestingModule } from "@angular/router/testing";
+import { SignInComponent } from "./sign-in.component";
+
+describe("SignInComponent", () => {
+  let component: SignInComponent;
+  let fixture: ComponentFixture<SignInComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SignInComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule, FormsModule],
+      providers: [{ provide: "BASE_URL", useValue: "https://www.smp.org/" }]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SignInComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
@@ -11,8 +11,13 @@ import { SignInRequest } from '../models/requests/sign-in-request';
 
 describe('SignInComponent', () => {
   const baseUrl: string = 'https://www.smp.org/';
+  const signInRequest: SignInRequest = {
+    email: 'MY@EMAIL.com',
+    password: '280913',
+  } as SignInRequest;
   let component: SignInComponent;
   let fixture: ComponentFixture<SignInComponent>;
+  let httpClientPostSpy: jasmine.Spy;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -22,20 +27,14 @@ describe('SignInComponent', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(SignInComponent);
     component = fixture.componentInstance;
+    component.signInRequest = signInRequest;
     fixture.detectChanges();
+    httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post');
   });
 
   describe('signIn', () => {
-    const signInRequest: SignInRequest = {
-      email: 'MY@EMAIL.com',
-      password: '280913',
-    } as SignInRequest;
-
     it('should get a 401 error from the API', () => {
-      const httpClientPostSpy: jasmine.Spy = spyOn(TestBed.get(HttpClient), 'post').and.returnValue(
-        throwError({ status: 401 })
-      );
-      component.signInRequest = signInRequest;
+      httpClientPostSpy.and.returnValue(throwError({ status: 401 }));
       component.signIn();
       expect(component.signInRequest.email).toEqual('my@email.com');
       expect(component.signInUnsuccessful).toEqual(true);
@@ -45,10 +44,7 @@ describe('SignInComponent', () => {
     });
 
     it('should get an error other than 401 from the API', () => {
-      const httpClientPostSpy: jasmine.Spy = spyOn(TestBed.get(HttpClient), 'post').and.returnValue(
-        throwError({ status: 500 })
-      );
-      component.signInRequest = signInRequest;
+      httpClientPostSpy.and.returnValue(throwError({ status: 500 }));
       component.signIn();
       expect(component.signInRequest.email).toEqual('my@email.com');
       expect(component.signInUnsuccessful).toEqual(true);
@@ -60,11 +56,8 @@ describe('SignInComponent', () => {
     });
 
     it('should navigate to /', () => {
-      const httpClientPostSpy: jasmine.Spy = spyOn(TestBed.get(HttpClient), 'post').and.returnValue(
-        of({ currentUser: 'bob' })
-      );
       const routerNavigateSpy: jasmine.Spy = spyOn(TestBed.get(Router), 'navigate');
-      component.signInRequest = signInRequest;
+      httpClientPostSpy.and.returnValue(of({ currentUser: 'bob' }));
       component.signIn();
       expect(component.signInRequest.email).toEqual('my@email.com');
       expect(localStorage.getItem('currentUser')).toEqual(JSON.stringify({ currentUser: 'bob' }));

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
@@ -4,8 +4,8 @@ import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { of, throwError } from 'rxjs';
+
 import { SignInComponent } from './sign-in.component';
 import { SignInRequest } from '../models/requests/sign-in-request';
 
@@ -55,7 +55,6 @@ describe('SignInComponent', () => {
       email: 'MY@EMAIL.com',
       password: '280913',
     } as SignInRequest;
-    let httpClientPostSpy: jasmine.Spy;
 
     beforeEach(() => {
       TestBed.configureTestingModule({
@@ -67,7 +66,7 @@ describe('SignInComponent', () => {
       component = fixture.componentInstance;
       fixture.detectChanges();
       component.signInRequest = signInRequest;
-      httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post');
+      spyOn(TestBed.get(HttpClient), 'post');
     });
 
     afterEach(() => {
@@ -78,14 +77,14 @@ describe('SignInComponent', () => {
     });
 
     it('should have received a 401 error from the API', () => {
-      httpClientPostSpy.and.callFake(() => throwError({ status: 401 }));
+      TestBed.get(HttpClient).post.and.callFake(() => throwError({ status: 401 }));
       component.signIn();
       expect(component.signInUnsuccessful).toBeTruthy();
       expect(component.errorMessage).toEqual('Invalid sign in details. Please try again.');
     });
 
     it('should have received an error other than 401 from the API', () => {
-      httpClientPostSpy.and.callFake(() => throwError({ status: 500 }));
+      TestBed.get(HttpClient).post.and.callFake(() => throwError({ status: 500 }));
       component.signIn();
       expect(component.signInUnsuccessful).toBeTruthy();
       expect(component.errorMessage).toEqual(
@@ -94,7 +93,7 @@ describe('SignInComponent', () => {
     });
 
     it("should have navigated to '/'", () => {
-      httpClientPostSpy.and.callFake(() => of({ currentUser: 'bob' }));
+      TestBed.get(HttpClient).post.and.callFake(() => of({ currentUser: 'bob' }));
       spyOn(TestBed.get(Router), 'navigate');
       component.signIn();
       expect(localStorage.getItem('currentUser')).toEqual(JSON.stringify({ currentUser: 'bob' }));

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
@@ -1,9 +1,9 @@
+import { ActivatedRoute, Router } from '@angular/router';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { of, throwError } from 'rxjs';
 import { SignInComponent } from './sign-in.component';
@@ -11,62 +11,98 @@ import { SignInRequest } from '../models/requests/sign-in-request';
 
 describe('SignInComponent', () => {
   const baseUrl: string = 'https://www.smp.org/';
-  const signInRequest: SignInRequest = {
-    email: 'MY@EMAIL.com',
-    password: '280913',
-  } as SignInRequest;
   let component: SignInComponent;
   let fixture: ComponentFixture<SignInComponent>;
-  let httpClientPostSpy: jasmine.Spy;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [SignInComponent],
-      imports: [RouterTestingModule, HttpClientTestingModule, FormsModule],
-      providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
-    }).compileComponents();
-    fixture = TestBed.createComponent(SignInComponent);
-    component = fixture.componentInstance;
-    component.signInRequest = signInRequest;
-    fixture.detectChanges();
-    httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post');
-  });
+  describe('ngOnInit()', () => {
+    function setUp(returnUrl: string, signUpSuccessful: string) {
+      TestBed.configureTestingModule({
+        declarations: [SignInComponent],
+        imports: [FormsModule, HttpClientTestingModule, RouterTestingModule],
+        providers: [
+          { provide: 'BASE_URL', useValue: baseUrl },
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              queryParams: of({ signUpSuccessful }),
+              snapshot: { queryParams: { returnUrl } },
+            },
+          },
+        ],
+      }).compileComponents();
+      fixture = TestBed.createComponent(SignInComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    }
 
-  describe('signIn', () => {
-    it('should get a 401 error from the API', () => {
-      httpClientPostSpy.and.returnValue(throwError({ status: 401 }));
-      component.signIn();
-      expect(component.signInRequest.email).toEqual('my@email.com');
-      expect(component.signInUnsuccessful).toEqual(true);
-      expect(component.errorMessage).toEqual('Invalid sign in details. Please try again.');
-      expect(httpClientPostSpy.calls.count()).toEqual(1);
-      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([`${baseUrl}api/Auth/SignIn`, signInRequest]);
+    it('should have set returnUrl to root and signUpSuccessful to true', () => {
+      setUp('/', 'true');
+      component.ngOnInit();
+      expect(component.returnUrl).toEqual('/');
+      expect(component.signUpSuccessful).toBeTruthy();
     });
 
-    it('should get an error other than 401 from the API', () => {
-      httpClientPostSpy.and.returnValue(throwError({ status: 500 }));
-      component.signIn();
+    it('should have set returnUrl to supplied param and signUpSuccessful to false', () => {
+      setUp('/not-root', 'false');
+      component.ngOnInit();
+      expect(component.returnUrl).toEqual('/not-root');
+      expect(component.signUpSuccessful).toBeFalsy();
+    });
+  });
+
+  describe('signIn()', () => {
+    const signInRequest: SignInRequest = {
+      email: 'MY@EMAIL.com',
+      password: '280913',
+    } as SignInRequest;
+    let httpClientPostSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [SignInComponent],
+        imports: [FormsModule, HttpClientTestingModule, RouterTestingModule],
+        providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
+      }).compileComponents();
+      fixture = TestBed.createComponent(SignInComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      component.signInRequest = signInRequest;
+      httpClientPostSpy = spyOn(TestBed.get(HttpClient), 'post');
+    });
+
+    afterEach(() => {
       expect(component.signInRequest.email).toEqual('my@email.com');
-      expect(component.signInUnsuccessful).toEqual(true);
+      expect(component.loading).toBeFalsy();
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(HttpClient).post).toHaveBeenCalledWith(`${baseUrl}api/Auth/SignIn`, signInRequest);
+    });
+
+    it('should have received a 401 error from the API', () => {
+      httpClientPostSpy.and.callFake(() => throwError({ status: 401 }));
+      component.signIn();
+      expect(component.signInUnsuccessful).toBeTruthy();
+      expect(component.errorMessage).toEqual('Invalid sign in details. Please try again.');
+    });
+
+    it('should have received an error other than 401 from the API', () => {
+      httpClientPostSpy.and.callFake(() => throwError({ status: 500 }));
+      component.signIn();
+      expect(component.signInUnsuccessful).toBeTruthy();
       expect(component.errorMessage).toEqual(
         'We are experiencing technical difficulties right now. Please try again later.'
       );
-      expect(httpClientPostSpy.calls.count()).toEqual(1);
-      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([`${baseUrl}api/Auth/SignIn`, signInRequest]);
     });
 
-    it('should navigate to /', () => {
-      const routerNavigateSpy: jasmine.Spy = spyOn(TestBed.get(Router), 'navigate');
-      httpClientPostSpy.and.returnValue(of({ currentUser: 'bob' }));
+    it("should have navigated to '/'", () => {
+      httpClientPostSpy.and.callFake(() => of({ currentUser: 'bob' }));
+      spyOn(TestBed.get(Router), 'navigate');
       component.signIn();
-      expect(component.signInRequest.email).toEqual('my@email.com');
       expect(localStorage.getItem('currentUser')).toEqual(JSON.stringify({ currentUser: 'bob' }));
+      expect(component.signInUnsuccessful).toBeFalsy();
+      expect(TestBed.get(Router).navigate).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(Router).navigate).toHaveBeenCalledWith(['/']);
+      // Clean up
       localStorage.removeItem('currentUser');
-      expect(component.signInUnsuccessful).toEqual(false);
-      expect(routerNavigateSpy.calls.count()).toEqual(1);
-      expect(routerNavigateSpy.calls.argsFor(0)).toEqual([['/']]);
-      expect(httpClientPostSpy.calls.count()).toEqual(1);
-      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([`${baseUrl}api/Auth/SignIn`, signInRequest]);
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.spec.ts
@@ -1,10 +1,16 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed, ComponentFixture } from "@angular/core/testing";
-import { FormsModule } from "@angular/forms";
-import { RouterTestingModule } from "@angular/router/testing";
-import { SignInComponent } from "./sign-in.component";
+import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-describe("SignInComponent", () => {
+import { of, throwError } from 'rxjs';
+import { SignInComponent } from './sign-in.component';
+import { SignInRequest } from '../models/requests/sign-in-request';
+
+describe('SignInComponent', () => {
+  const baseUrl: string = 'https://www.smp.org/';
   let component: SignInComponent;
   let fixture: ComponentFixture<SignInComponent>;
 
@@ -12,14 +18,62 @@ describe("SignInComponent", () => {
     TestBed.configureTestingModule({
       declarations: [SignInComponent],
       imports: [RouterTestingModule, HttpClientTestingModule, FormsModule],
-      providers: [{ provide: "BASE_URL", useValue: "https://www.smp.org/" }]
+      providers: [{ provide: 'BASE_URL', useValue: baseUrl }],
     }).compileComponents();
     fixture = TestBed.createComponent(SignInComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe('signIn', () => {
+    const signInRequest: SignInRequest = {
+      email: 'MY@EMAIL.com',
+      password: '280913',
+    } as SignInRequest;
+
+    it('should get a 401 error from the API', () => {
+      const httpClientPostSpy: jasmine.Spy = spyOn(TestBed.get(HttpClient), 'post').and.returnValue(
+        throwError({ status: 401 })
+      );
+      component.signInRequest = signInRequest;
+      component.signIn();
+      expect(component.signInRequest.email).toEqual('my@email.com');
+      expect(component.signInUnsuccessful).toEqual(true);
+      expect(component.errorMessage).toEqual('Invalid sign in details. Please try again.');
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([`${baseUrl}api/Auth/SignIn`, signInRequest]);
+    });
+
+    it('should get an error other than 401 from the API', () => {
+      const httpClientPostSpy: jasmine.Spy = spyOn(TestBed.get(HttpClient), 'post').and.returnValue(
+        throwError({ status: 500 })
+      );
+      component.signInRequest = signInRequest;
+      component.signIn();
+      expect(component.signInRequest.email).toEqual('my@email.com');
+      expect(component.signInUnsuccessful).toEqual(true);
+      expect(component.errorMessage).toEqual(
+        'We are experiencing technical difficulties right now. Please try again later.'
+      );
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([`${baseUrl}api/Auth/SignIn`, signInRequest]);
+    });
+
+    it('should navigate to /', () => {
+      const httpClientPostSpy: jasmine.Spy = spyOn(TestBed.get(HttpClient), 'post').and.returnValue(
+        of({ currentUser: 'bob' })
+      );
+      const routerNavigateSpy: jasmine.Spy = spyOn(TestBed.get(Router), 'navigate');
+      component.signInRequest = signInRequest;
+      component.signIn();
+      expect(component.signInRequest.email).toEqual('my@email.com');
+      expect(localStorage.getItem('currentUser')).toEqual(JSON.stringify({ currentUser: 'bob' }));
+      localStorage.removeItem('currentUser');
+      expect(component.signInUnsuccessful).toEqual(false);
+      expect(routerNavigateSpy.calls.count()).toEqual(1);
+      expect(routerNavigateSpy.calls.argsFor(0)).toEqual([['/']]);
+      expect(httpClientPostSpy.calls.count()).toEqual(1);
+      expect(httpClientPostSpy.calls.argsFor(0)).toEqual([`${baseUrl}api/Auth/SignIn`, signInRequest]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.ts
@@ -1,12 +1,13 @@
+import { ActivatedRoute, Router } from '@angular/router';
 import { Component, Inject, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+
 import { SignInRequest } from '../models/requests/sign-in-request';
-import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-sign-in',
   templateUrl: './sign-in.component.html',
-  styleUrls: ['./sign-in.component.scss']
+  styleUrls: ['./sign-in.component.scss'],
 })
 export class SignInComponent implements OnInit {
   private readonly baseUrl: string;
@@ -50,11 +51,12 @@ export class SignInComponent implements OnInit {
       },
       error: (error: any) => {
         this.signInUnsuccessful = true;
-        this.errorMessage = error.status === 401
-          ? "Invalid sign in details. Please try again."
-          : "We are experiencing technical difficulties right now. Please try again later.";
-          this.loading = false;
-      }
+        this.errorMessage =
+          error.status === 401
+            ? 'Invalid sign in details. Please try again.'
+            : 'We are experiencing technical difficulties right now. Please try again later.';
+        this.loading = false;
+      },
     });
   }
 }

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.ts
@@ -10,14 +10,14 @@ import { SignInRequest } from '../models/requests/sign-in-request';
   styleUrls: ['./sign-in.component.scss'],
 })
 export class SignInComponent implements OnInit {
-  private readonly baseUrl: string;
-  private readonly httpClient: HttpClient;
-  public signInRequest: SignInRequest = new SignInRequest();
+  public errorMessage: string;
   public loading: boolean = false;
   public returnUrl: string;
-  public signUpSuccessful: boolean = false;
+  public signInRequest: SignInRequest = new SignInRequest();
   public signInUnsuccessful: boolean = false;
-  public errorMessage: string;
+  public signUpSuccessful: boolean = false;
+  private readonly baseUrl: string;
+  private readonly httpClient: HttpClient;
 
   constructor(
     http: HttpClient,
@@ -40,8 +40,8 @@ export class SignInComponent implements OnInit {
 
   public signIn(): void {
     this.loading = true;
-    this.signUpSuccessful = false;
     this.signInRequest.email = this.signInRequest.email.toLowerCase();
+    this.signUpSuccessful = false;
 
     this.httpClient.post(this.baseUrl + 'api/Auth/SignIn', this.signInRequest).subscribe({
       next: (result: any) => {
@@ -51,10 +51,9 @@ export class SignInComponent implements OnInit {
       },
       error: (error: any) => {
         this.signInUnsuccessful = true;
-        this.errorMessage =
-          error.status === 401
-            ? 'Invalid sign in details. Please try again.'
-            : 'We are experiencing technical difficulties right now. Please try again later.';
+        this.errorMessage =error.status === 401
+          ? 'Invalid sign in details. Please try again.'
+          : 'We are experiencing technical difficulties right now. Please try again later.';
         this.loading = false;
       },
     });

--- a/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-in/sign-in.component.ts
@@ -38,7 +38,7 @@ export class SignInComponent implements OnInit {
     });
   }
 
-  public signIn() {
+  public signIn(): void {
     this.loading = true;
     this.signUpSuccessful = false;
     this.signInRequest.email = this.signInRequest.email.toLowerCase();

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
@@ -1,0 +1,25 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { RouterTestingModule } from "@angular/router/testing";
+import { SignUpComponent } from "./sign-up.component";
+
+describe("SignUpComponent", () => {
+  let component: SignUpComponent;
+  let fixture: ComponentFixture<SignUpComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SignUpComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule, FormsModule],
+      providers: [{ provide: "BASE_URL", useValue: "https://www.smp.org/" }]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SignUpComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
@@ -3,8 +3,8 @@ import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError} from 'rxjs';
 
-import { throwError, of } from 'rxjs';
 import { CreateUserRequest } from '../models/requests/create-user-request';
 import { Error } from '../models/error';
 import { SignUpComponent } from './sign-up.component';

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
@@ -1,8 +1,8 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TestBed, ComponentFixture } from '@angular/core/testing';
 
 import { throwError, of } from 'rxjs';
 import { CreateUserRequest } from '../models/requests/create-user-request';
@@ -11,6 +11,12 @@ import { SignUpComponent } from './sign-up.component';
 import { UsersService } from '../services/users.service';
 
 describe('SignUpComponent', () => {
+  const createUserRequest: CreateUserRequest = {
+    fullName: 'c',
+    password: '09876',
+    confirmPassword: '09876',
+    email: 'my@EMAIL.com',
+  } as CreateUserRequest;
   let component: SignUpComponent;
   let fixture: ComponentFixture<SignUpComponent>;
 
@@ -18,62 +24,49 @@ describe('SignUpComponent', () => {
     TestBed.configureTestingModule({
       declarations: [SignUpComponent],
       imports: [RouterTestingModule, HttpClientTestingModule, FormsModule],
-      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }, UsersService],
+      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }],
     }).compileComponents();
     fixture = TestBed.createComponent(SignUpComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  describe('signUp', () => {
-    it('should have a validation error due to passwords not matching', () => {
-      component.createUserRequest.password = '09876';
+  describe('signUp()', () => {
+    it('should have set a validation error due to passwords not matching', () => {
+      component.createUserRequest.password = createUserRequest.password;
       component.createUserRequest.confirmPassword = '12345';
       component.signUp();
       expect(component.validationErrors.length).toEqual(1);
       expect(component.validationErrors[0].key).toEqual('invalid_password');
     });
 
-    it('should have a validation error coming from the API', () => {
-      const createUserRequest: CreateUserRequest = {
-        fullName: 'c',
-        password: '09876',
-        confirmPassword: '09876',
-        email: 'my@EMAIL.com',
-      } as CreateUserRequest;
-      const usersServiceCreateUserSpy: jasmine.Spy = spyOn(TestBed.get(UsersService), 'createUser').and.returnValue(
-        throwError({
-          error: new Error('invalid_full_name', 'Full name must have at least 3 characters.'),
-        })
+    it('should have set a validation error coming from the API', () => {
+      spyOn(TestBed.get(UsersService), 'createUser').and.callFake(() =>
+        throwError({ error: new Error('invalid_full_name', '') })
       );
       component.createUserRequest = createUserRequest;
       component.signUp();
       expect(component.createUserRequest.email).toEqual('my@email.com');
       expect(component.validationErrors.length).toEqual(1);
       expect(component.validationErrors[0].key).toEqual('invalid_full_name');
-      expect(usersServiceCreateUserSpy.calls.count()).toEqual(1);
-      expect(usersServiceCreateUserSpy.calls.argsFor(0)).toEqual([createUserRequest]);
+      expect(TestBed.get(UsersService).createUser).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(UsersService).createUser).toHaveBeenCalledWith(createUserRequest);
     });
 
-    it('should navigate to /sign-in', () => {
-      const createUserRequest: CreateUserRequest = {
-        fullName: 'cknjqwer',
-        password: '09876',
-        confirmPassword: '09876',
-        email: 'my@EMAIL.com',
-      } as CreateUserRequest;
-      const usersServiceCreateUserSpy: jasmine.Spy = spyOn(TestBed.get(UsersService), 'createUser').and.returnValue(
-        of({})
-      );
-      const routerNavigateSpy: jasmine.Spy = spyOn(TestBed.get(Router), 'navigate');
+    it('should have navigated to /sign-in', () => {
+      spyOn(TestBed.get(UsersService), 'createUser').and.callFake(() => of({}));
+      spyOn(TestBed.get(Router), 'navigate');
       component.createUserRequest = createUserRequest;
       component.signUp();
       expect(component.createUserRequest.email).toEqual('my@email.com');
       expect(component.validationErrors.length).toEqual(0);
-      expect(usersServiceCreateUserSpy.calls.count()).toEqual(1);
-      expect(usersServiceCreateUserSpy.calls.argsFor(0)).toEqual([createUserRequest]);
-      expect(routerNavigateSpy.calls.count()).toEqual(1);
-      expect(routerNavigateSpy.calls.argsFor(0)).toEqual([['/sign-in'], { queryParams: { signUpSuccessful: 'true' } }]);
+      expect(TestBed.get(UsersService).createUser).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(UsersService).createUser).toHaveBeenCalledWith(createUserRequest);
+      expect(TestBed.get(Router).navigate).toHaveBeenCalledTimes(1);
+      expect(TestBed.get(Router).navigate).toHaveBeenCalledWith(
+        ['/sign-in'],
+        { queryParams: { signUpSuccessful: 'true' } }
+      );
     });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
@@ -31,6 +31,12 @@ describe('SignUpComponent', () => {
     fixture.detectChanges();
   });
 
+  afterAll(() => {
+    if (fixture.nativeElement && 'remove' in fixture.nativeElement) {
+      (fixture.nativeElement as HTMLElement).remove();
+    }
+  });
+
   describe('signUp()', () => {
     it('should have set a validation error due to passwords not matching', () => {
       component.createUserRequest.password = createUserRequest.password;

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
@@ -1,10 +1,16 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed, ComponentFixture } from "@angular/core/testing";
-import { FormsModule } from "@angular/forms";
-import { RouterTestingModule } from "@angular/router/testing";
-import { SignUpComponent } from "./sign-up.component";
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 
-describe("SignUpComponent", () => {
+import { throwError, of } from 'rxjs';
+import { CreateUserRequest } from '../models/requests/create-user-request';
+import { Error } from '../models/error';
+import { SignUpComponent } from './sign-up.component';
+import { UsersService } from '../services/users.service';
+
+describe('SignUpComponent', () => {
   let component: SignUpComponent;
   let fixture: ComponentFixture<SignUpComponent>;
 
@@ -12,14 +18,62 @@ describe("SignUpComponent", () => {
     TestBed.configureTestingModule({
       declarations: [SignUpComponent],
       imports: [RouterTestingModule, HttpClientTestingModule, FormsModule],
-      providers: [{ provide: "BASE_URL", useValue: "https://www.smp.org/" }]
+      providers: [{ provide: 'BASE_URL', useValue: 'https://www.smp.org/' }, UsersService],
     }).compileComponents();
     fixture = TestBed.createComponent(SignUpComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe('signUp', () => {
+    it('should have a validation error due to passwords not matching', () => {
+      component.createUserRequest.password = '09876';
+      component.createUserRequest.confirmPassword = '12345';
+      component.signUp();
+      expect(component.validationErrors.length).toEqual(1);
+      expect(component.validationErrors[0].key).toEqual('invalid_password');
+    });
+
+    it('should have a validation error coming from the API', () => {
+      const createUserRequest: CreateUserRequest = {
+        fullName: 'c',
+        password: '09876',
+        confirmPassword: '09876',
+        email: 'my@EMAIL.com',
+      } as CreateUserRequest;
+      const usersServiceCreateUserSpy: jasmine.Spy = spyOn(TestBed.get(UsersService), 'createUser').and.returnValue(
+        throwError({
+          error: new Error('invalid_full_name', 'Full name must have at least 3 characters.'),
+        })
+      );
+      component.createUserRequest = createUserRequest;
+      component.signUp();
+      expect(component.createUserRequest.email).toEqual('my@email.com');
+      expect(component.validationErrors.length).toEqual(1);
+      expect(component.validationErrors[0].key).toEqual('invalid_full_name');
+      expect(usersServiceCreateUserSpy.calls.count()).toEqual(1);
+      expect(usersServiceCreateUserSpy.calls.argsFor(0).toString()).toEqual(createUserRequest.toString());
+    });
+
+    it('should navigate to /sign-in', () => {
+      const createUserRequest: CreateUserRequest = {
+        fullName: 'cknjqwer',
+        password: '09876',
+        confirmPassword: '09876',
+        email: 'my@EMAIL.com',
+      } as CreateUserRequest;
+      const usersServiceCreateUserSpy: jasmine.Spy = spyOn(TestBed.get(UsersService), 'createUser').and.returnValue(
+        of({})
+      );
+      const routerNavigateSpy: jasmine.Spy = spyOn(TestBed.get(Router), 'navigate');
+      component.createUserRequest = createUserRequest;
+      component.signUp();
+      expect(component.createUserRequest.email).toEqual('my@email.com');
+      expect(component.validationErrors.length).toEqual(0);
+      expect(usersServiceCreateUserSpy.calls.count()).toEqual(1);
+      expect(usersServiceCreateUserSpy.calls.argsFor(0).toString()).toEqual(createUserRequest.toString());
+      expect(routerNavigateSpy.calls.count()).toEqual(1);
+      expect(routerNavigateSpy.calls.argsFor(0)).toEqual([['/sign-in'], { queryParams: { signUpSuccessful: 'true' } }]);
+    });
   });
 });

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.spec.ts
@@ -52,7 +52,7 @@ describe('SignUpComponent', () => {
       expect(component.validationErrors.length).toEqual(1);
       expect(component.validationErrors[0].key).toEqual('invalid_full_name');
       expect(usersServiceCreateUserSpy.calls.count()).toEqual(1);
-      expect(usersServiceCreateUserSpy.calls.argsFor(0).toString()).toEqual(createUserRequest.toString());
+      expect(usersServiceCreateUserSpy.calls.argsFor(0)).toEqual([createUserRequest]);
     });
 
     it('should navigate to /sign-in', () => {
@@ -71,7 +71,7 @@ describe('SignUpComponent', () => {
       expect(component.createUserRequest.email).toEqual('my@email.com');
       expect(component.validationErrors.length).toEqual(0);
       expect(usersServiceCreateUserSpy.calls.count()).toEqual(1);
-      expect(usersServiceCreateUserSpy.calls.argsFor(0).toString()).toEqual(createUserRequest.toString());
+      expect(usersServiceCreateUserSpy.calls.argsFor(0)).toEqual([createUserRequest]);
       expect(routerNavigateSpy.calls.count()).toEqual(1);
       expect(routerNavigateSpy.calls.argsFor(0)).toEqual([['/sign-in'], { queryParams: { signUpSuccessful: 'true' } }]);
     });

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { CreateUserRequest } from '../models/requests/create-user-request';
 import { Error } from '../models/error';
-import { Router } from '@angular/router';
 import { UsersService } from '../services/users.service';
 
 @Component({
@@ -36,7 +36,7 @@ export class SignUpComponent {
         this.router.navigate(['/sign-in'], { queryParams: { signUpSuccessful: 'true' } });
       },
       error: (error: any) => {
-        this.validationErrors = error.error;
+        this.validationErrors.push(error.error);
         this.loading = false;
       }
     });

--- a/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.ts
+++ b/src/Smp.Web/ClientApp/src/app/sign-up/sign-up.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { CreateUserRequest } from '../models/requests/create-user-request';
 import { Error } from '../models/error';
 import { Router } from '@angular/router';


### PR DESCRIPTION
### TODO
- [x] Remove unnecessary providers across the tests (i.e. remove those created by us).
- [x] (optional) Rewrite the `expect()` calls to the verbose form ([explanation](https://github.com/smp-org/smp/wiki/Angular-Unit-Tests#prefer-verbose-expect-functions)) – **ongoing effort**.
- [x] Consider testing the `ngOnInit()` lifecycle methods.
- [x] Remove the sign-up component from the bottom of the Karma page.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/42574496/76246489-b94f6b80-6235-11ea-9596-c7269fdd7d7d.png">

- [ ] Consider adding the following snippet to all component tests to prevent issues with unwanted elements being rendered on the Karma results page. (Although, keep in mind that the behaviour is correct and to be expected with the current implementation of the tests. A 'more correct' solution would be to take [this approach](https://angular.io/guide/testing#component-class-testing).)

```TypeScript
afterAll(() => {
  if (fixture.nativeElement && 'remove' in fixture.nativeElement) {
    (fixture.nativeElement as HTMLElement).remove();
  }
});
```